### PR TITLE
Fix: removed mid-game player no longer becomes winner (Cricket/X01/ATC)

### DIFF
--- a/docs/superpowers/plans/2026-05-13-removed-player-winner-fix-plan.md
+++ b/docs/superpowers/plans/2026-05-13-removed-player-winner-fix-plan.md
@@ -1,0 +1,558 @@
+# Removed mid-game player winner fix — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A player removed mid-game in Cricket, X01, or Around the Clock must never be declared the winner.
+
+**Architecture:** Minimal-blast-radius fix. Add a private helper `_winnerIndexExcludingRemoved()` per game screen that walks `finishedPlayers` and returns the first index not in `_removedPlayerIndices`. Replace all `finishedPlayers.first`-based winner picks with the helper. Leave `finishedPlayers` membership semantics alone — removed players continue to be added to `finishedPlayers` so existing "is this player still playing?" checks across ~70 sites stay correct.
+
+**Tech Stack:** Flutter (Dart), existing `flutter_test` widget tests.
+
+**Spec:** `docs/superpowers/specs/2026-05-13-removed-player-winner-fix-design.md` (commit `3941a8a`).
+
+**Trade-off acknowledged in plan:** The spec discussed two approaches — (A) drop `finishedPlayers.add(playerIndex)` in the remove handler and audit ~70 `finishedPlayers.contains`/`length` sites, or (B) change only the winner-picking. This plan goes with (B). It fixes the user-visible bug (removed player declared winner) without rewriting placement logic. If a follow-up reveals that removed players still appear in the wrong rank on post-game (e.g., as `2nd place` instead of `removed`), that becomes a separate spec/PR.
+
+---
+
+## File map
+
+**Modified:**
+- `lib/screens/cricket_game_screen.dart` — add `_winnerIndexExcludingRemoved()` helper; replace winner picks at lines 142, 145, 373
+- `lib/screens/game_screen.dart` (X01) — add helper; replace at lines 506, 725, 738, 820, 836, 914, 934, 1056
+- `lib/screens/around_the_clock_game_screen.dart` — add helper; replace at lines 381, 424, 504, 727, 797
+
+**Created:**
+- `test/screens/removed_player_winner_test.dart` — one parameterized-style test per affected mode
+
+**Verified, no change:**
+- `lib/screens/halve_it_game_screen.dart` — winner is highest score; remove handler at line 1197 only adds to `_removedPlayerIndices`, not `finishedPlayers`
+- `lib/screens/killer_game_screen.dart` — already filters via `isEliminated` + `_removedPlayerIndices.contains` checks
+- `lib/screens/shanghai_game_screen.dart` — engine-based winner pattern
+
+---
+
+## Task 1: Cricket — helper + winner pick replacements
+
+**Files:**
+- Modify: `lib/screens/cricket_game_screen.dart` (new helper near `_removedPlayerIndices` field declaration; line replacements at 142, 145, 373)
+
+- [ ] **Step 1.1: Confirm exact line numbers and field types**
+
+Before editing, run:
+```bash
+cd .worktrees/removed-player-fix
+grep -n "finishedPlayers\.first\|_removedPlayerIndices\s*=\|int? winnerIndex\|int winnerIndex" lib/screens/cricket_game_screen.dart
+```
+
+This pins the current line numbers (drift since plan was written) and confirms whether `winnerIndex` is `int?` or `int`. The replacements in Steps 1.3-1.5 assume the helper returns `int?`; if a call site assigns to non-nullable `int`, add `!` after the helper call where the surrounding logic guarantees a winner exists.
+
+- [ ] **Step 1.2: Add the helper method**
+
+In `lib/screens/cricket_game_screen.dart`, find the section near the top of `_CricketGameScreenState` where `_removedPlayerIndices` is declared (search for `final Set<int> _removedPlayerIndices` or similar). Immediately after the field declarations, add:
+
+```dart
+  /// First player in [finishedPlayers] who has not been removed mid-game.
+  /// Used for winner picking — a removed player must never be declared winner
+  /// even if their index happens to appear first in [finishedPlayers].
+  int? _winnerIndexExcludingRemoved() {
+    for (final i in finishedPlayers) {
+      if (!_removedPlayerIndices.contains(i)) return i;
+    }
+    return null;
+  }
+```
+
+- [ ] **Step 1.3: Replace winner pick at line ~142**
+
+Current code (approximate — confirm via Step 1.1):
+```dart
+            winnerIndex = finishedPlayers.first;
+```
+Replace with:
+```dart
+            winnerIndex = _winnerIndexExcludingRemoved() ?? finishedPlayers.first;
+```
+
+The `?? finishedPlayers.first` fallback preserves the original behaviour when *all* finishers are removed (an edge case where someone removed the entire field; falling back to the old logic is safer than crashing).
+
+- [ ] **Step 1.4: Replace winner pick at line ~145**
+
+Same change as Step 1.3 — find the second `winnerIndex = finishedPlayers.first;` in the file and apply the identical replacement.
+
+- [ ] **Step 1.5: Replace winner pick at line ~373**
+
+Current code (approximate):
+```dart
+      winnerIndex = finishedPlayers.isNotEmpty ? finishedPlayers.first : null;
+```
+Replace with:
+```dart
+      winnerIndex = _winnerIndexExcludingRemoved();
+```
+
+(The helper already returns `null` when `finishedPlayers` is empty, so the ternary is redundant.)
+
+- [ ] **Step 1.6: Run analyzer**
+
+```bash
+cd .worktrees/removed-player-fix
+flutter analyze lib/screens/cricket_game_screen.dart
+```
+Expected: no issues. If a `null` type mismatch surfaces, add `!` only where the surrounding logic guarantees at least one non-removed finisher (typically inside an `if (finishedPlayers.length >= players.length - 1)` block).
+
+- [ ] **Step 1.7: Do NOT commit yet**
+
+Commit comes after all three files + tests land together in Task 5.
+
+---
+
+## Task 2: X01 — helper + winner pick replacements
+
+**Files:**
+- Modify: `lib/screens/game_screen.dart` (helper + replacements at lines 506, 725, 738, 820, 836, 914, 934, 1056)
+
+- [ ] **Step 2.1: Confirm line numbers**
+
+```bash
+cd .worktrees/removed-player-fix
+grep -n "finishedPlayers\.first" lib/screens/game_screen.dart
+```
+
+Expected output: 8 lines — 506, 725, 738, 820, 836, 914, 934, 1056. If drift, use the current numbers.
+
+- [ ] **Step 2.2: Add the helper method**
+
+In `lib/screens/game_screen.dart`, find the section where `_removedPlayerIndices` is declared (search for `_removedPlayerIndices`). Add immediately after the field declarations:
+
+```dart
+  /// First player in [finishedPlayers] who has not been removed mid-game.
+  /// Used for winner picking — a removed player must never be declared winner
+  /// even if their index happens to appear first in [finishedPlayers].
+  int? _winnerIndexExcludingRemoved() {
+    for (final i in finishedPlayers) {
+      if (!_removedPlayerIndices.contains(i)) return i;
+    }
+    return null;
+  }
+```
+
+- [ ] **Step 2.3: Replace lines 725, 820, 914**
+
+These three sites have the pattern:
+```dart
+        winnerIndex = finishedPlayers.first;
+```
+Replace each with:
+```dart
+        winnerIndex = _winnerIndexExcludingRemoved() ?? finishedPlayers.first;
+```
+
+- [ ] **Step 2.4: Replace line 1056**
+
+Current:
+```dart
+      winnerIndex = finishedPlayers.isNotEmpty ? finishedPlayers.first : null;
+```
+Replace with:
+```dart
+      winnerIndex = _winnerIndexExcludingRemoved();
+```
+
+- [ ] **Step 2.5: Replace lines 506, 738, 836, 934 (downstream `finishedPlayers.first == pi` checks)**
+
+These sites use `finishedPlayers.first` to identify the winner for stats consumers (e.g., `sp.gamesWon++`). Line 506 looks like:
+
+```dart
+      if (finishedPlayers.isNotEmpty && finishedPlayers.first == pi) sp.gamesWon++;
+```
+
+Replace with:
+```dart
+      if (_winnerIndexExcludingRemoved() == pi) sp.gamesWon++;
+```
+
+(The helper returns `null` when no real winner exists, and `null == pi` is `false` — handles the empty case correctly.)
+
+For lines 738, 836, 934, the surrounding code looks like:
+
+```dart
+      final winner = players[finishedPlayers.first];
+```
+
+Replace with:
+```dart
+      final winner = players[_winnerIndexExcludingRemoved() ?? finishedPlayers.first];
+```
+
+Same fallback as Step 2.3 — preserves crash-free behaviour if every finisher is removed.
+
+- [ ] **Step 2.6: Run analyzer**
+
+```bash
+cd .worktrees/removed-player-fix
+flutter analyze lib/screens/game_screen.dart
+```
+Expected: no issues.
+
+- [ ] **Step 2.7: Do NOT commit yet**
+
+---
+
+## Task 3: ATC — helper + winner pick replacements
+
+**Files:**
+- Modify: `lib/screens/around_the_clock_game_screen.dart` (helper + replacements at lines 381, 424, 504, 727, 797)
+
+- [ ] **Step 3.1: Confirm line numbers**
+
+```bash
+cd .worktrees/removed-player-fix
+grep -n "finishedPlayers\.first" lib/screens/around_the_clock_game_screen.dart
+```
+
+Expected: 5 lines — 381, 424, 504, 727, 797.
+
+- [ ] **Step 3.2: Add the helper method**
+
+Same body as Task 1.2 and 2.2. Place it just after `_removedPlayerIndices` field declaration:
+
+```dart
+  /// First player in [finishedPlayers] who has not been removed mid-game.
+  /// Used for winner picking — a removed player must never be declared winner
+  /// even if their index happens to appear first in [finishedPlayers].
+  int? _winnerIndexExcludingRemoved() {
+    for (final i in finishedPlayers) {
+      if (!_removedPlayerIndices.contains(i)) return i;
+    }
+    return null;
+  }
+```
+
+- [ ] **Step 3.3: Replace lines 424, 504**
+
+Both look like:
+```dart
+      winnerIndex = finishedPlayers.first;
+```
+Replace each with:
+```dart
+      winnerIndex = _winnerIndexExcludingRemoved() ?? finishedPlayers.first;
+```
+
+- [ ] **Step 3.4: Replace lines 381, 727**
+
+Both look like:
+```dart
+      winnerIndex = finishedPlayers.isNotEmpty ? finishedPlayers.first : null;
+```
+Replace each with:
+```dart
+      winnerIndex = _winnerIndexExcludingRemoved();
+```
+
+- [ ] **Step 3.5: Replace line 797 (downstream stats check)**
+
+Current:
+```dart
+      if (finishedPlayers.isNotEmpty && finishedPlayers.first == pi) sp.gamesWon++;
+```
+Replace with:
+```dart
+      if (_winnerIndexExcludingRemoved() == pi) sp.gamesWon++;
+```
+
+- [ ] **Step 3.6: Run analyzer**
+
+```bash
+cd .worktrees/removed-player-fix
+flutter analyze lib/screens/around_the_clock_game_screen.dart
+```
+Expected: no issues.
+
+- [ ] **Step 3.7: Do NOT commit yet**
+
+---
+
+## Task 4: Regression tests — one per affected mode
+
+**Files:**
+- Create: `test/screens/removed_player_winner_test.dart`
+
+Each test follows the same shape: mount the game screen with 3 players, drive the engine far enough that P1 can finish, remove P0 mid-game, finish P1, assert `winnerIndex == 1`.
+
+The simplest way to drive each engine in tests is via a `@visibleForTesting` getter on the State class — exposing the underlying engine + the `_removedPlayerIndices` field. This may already exist for some screens; if not, add it.
+
+- [ ] **Step 4.1: Expose test hooks on each game screen**
+
+For each of `cricket_game_screen.dart`, `game_screen.dart`, `around_the_clock_game_screen.dart`, add (or confirm exists) near the top of the State class:
+
+```dart
+  @visibleForTesting
+  List<int> get finishedPlayersForTest => finishedPlayers;
+
+  @visibleForTesting
+  Set<int> get removedPlayerIndicesForTest => _removedPlayerIndices;
+
+  @visibleForTesting
+  int? get winnerIndexForTest => winnerIndex;
+```
+
+Plus a `@visibleForTesting` method that directly invokes the remove flow and the finish flow (these typically live in `_removePlayerMidGame` and `_handleCheckout` or similar — search each file):
+
+```dart
+  @visibleForTesting
+  void removePlayerForTest(int playerIndex) {
+    setState(() {
+      _midGamePlayerChanges = true;
+      _removedPlayerIndices.add(playerIndex);
+      if (!finishedPlayers.contains(playerIndex)) {
+        finishedPlayers.add(playerIndex);
+      }
+      // Skip the dialog and any side-effects the dialog handler does
+      // beyond what the bug fix covers. If the file has additional logic
+      // (e.g., advancing the current player when removing the active one),
+      // mirror it here. See the production _removePlayerMidGame for what
+      // happens inside the Remove button's onPressed.
+    });
+  }
+```
+
+⚠ **Important:** When copying the body from `_removePlayerMidGame`, omit any UI-only side effects (Navigator pops, dialogs) but keep the state mutations. Cross-check against the production handler in each file.
+
+Add `import 'package:flutter/foundation.dart';` if needed for `@visibleForTesting`.
+
+- [ ] **Step 4.2: Write the Cricket test**
+
+Create `test/screens/removed_player_winner_test.dart` and start with the Cricket case:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dart_scoring/models/game_config.dart';
+import 'package:dart_scoring/models/player.dart';
+import 'package:dart_scoring/screens/cricket_game_screen.dart';
+
+void main() {
+  testWidgets('Cricket: removed mid-game player does not become winner',
+      (tester) async {
+    final players = [
+      Player(name: 'P0', score: 0),
+      Player(name: 'P1', score: 0),
+      Player(name: 'P2', score: 0),
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      home: CricketGameScreen(
+        players: players,
+        config: const CricketConfig(
+          isRandom: false,
+          targetCount: 7,
+          includeBull: false,
+          isCutthroat: false,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final state = tester.state<State<CricketGameScreen>>(
+        find.byType(CricketGameScreen));
+    final dynamic dynState = state;
+
+    // Remove P0 mid-game — index 0 lands in both finishedPlayers and
+    // _removedPlayerIndices, mimicking the production handler.
+    dynState.removePlayerForTest(0);
+    await tester.pumpAndSettle();
+
+    expect(dynState.removedPlayerIndicesForTest.contains(0), isTrue);
+    expect(dynState.finishedPlayersForTest.first, equals(0),
+        reason: 'precondition: removed player must be first in finishedPlayers '
+            'for the bug to surface; the helper must skip them');
+
+    // Simulate P1 finishing — add to finishedPlayers second.
+    dynState.finishedPlayersForTest.add(1);
+    // Trigger the winner-pick path. The actual path differs per file —
+    // for Cricket the simplest is to call the existing _checkGameOver-style
+    // method via a test hook. If that's not exposed, call the helper
+    // directly through a @visibleForTesting wrapper that runs the same
+    // assignment as the production code at line ~142.
+    final winner = dynState.computeWinnerForTest();
+    expect(winner, equals(1),
+        reason: 'P1 should be the winner — P0 was removed mid-game');
+  });
+}
+```
+
+⚠ The test references `dynState.computeWinnerForTest()` — a thin wrapper around `_winnerIndexExcludingRemoved()` exposed for tests. Add this getter to the State class:
+
+```dart
+  @visibleForTesting
+  int? computeWinnerForTest() => _winnerIndexExcludingRemoved();
+```
+
+This is the minimum viable test — it directly exercises the helper logic in the context where the bug surfaces. A fuller test driving real throws is preferable but significantly more code; this minimal version verifies the contract.
+
+- [ ] **Step 4.3: Add the X01 case**
+
+Append to the same test file:
+
+```dart
+import 'package:dart_scoring/screens/game_screen.dart';
+
+// ... in main() body, after Cricket test:
+
+  testWidgets('X01: removed mid-game player does not become winner',
+      (tester) async {
+    final players = [
+      Player(name: 'P0', score: 301),
+      Player(name: 'P1', score: 301),
+      Player(name: 'P2', score: 301),
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      home: GameScreen(
+        players: players,
+        startingScore: 301,
+        masterOut: 'none',
+        handicap: false,
+        noBust: false,
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final state =
+        tester.state<State<GameScreen>>(find.byType(GameScreen));
+    final dynamic dynState = state;
+
+    dynState.removePlayerForTest(0);
+    await tester.pumpAndSettle();
+
+    dynState.finishedPlayersForTest.add(1);
+    final winner = dynState.computeWinnerForTest();
+    expect(winner, equals(1),
+        reason: 'P1 should be the winner — P0 was removed mid-game');
+  });
+```
+
+- [ ] **Step 4.4: Add the ATC case**
+
+Append:
+
+```dart
+import 'package:dart_scoring/screens/around_the_clock_game_screen.dart';
+
+// ... in main() body:
+
+  testWidgets('ATC: removed mid-game player does not become winner',
+      (tester) async {
+    final players = [
+      Player(name: 'P0', score: 0),
+      Player(name: 'P1', score: 0),
+      Player(name: 'P2', score: 0),
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      home: AroundTheClockGameScreen(
+        players: players,
+        config: const AroundTheClockConfig(
+          includeBull: false,
+          countMultiples: false,
+          reverse: false,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final state = tester.state<State<AroundTheClockGameScreen>>(
+        find.byType(AroundTheClockGameScreen));
+    final dynamic dynState = state;
+
+    dynState.removePlayerForTest(0);
+    await tester.pumpAndSettle();
+
+    dynState.finishedPlayersForTest.add(1);
+    final winner = dynState.computeWinnerForTest();
+    expect(winner, equals(1),
+        reason: 'P1 should be the winner — P0 was removed mid-game');
+  });
+```
+
+Verify each screen's constructor signature matches what's used in these tests. Adjust required parameters as needed by reading each constructor.
+
+- [ ] **Step 4.5: Run the new tests**
+
+```bash
+cd .worktrees/removed-player-fix
+flutter test test/screens/removed_player_winner_test.dart
+```
+Expected: 3 tests pass.
+
+- [ ] **Step 4.6: Run the full test suite**
+
+```bash
+cd .worktrees/removed-player-fix
+flutter test
+```
+Expected: all tests pass (existing + new).
+
+---
+
+## Task 5: Final analyzer + commit
+
+**Files:** none (verification + commit only)
+
+- [ ] **Step 5.1: Run analyzer over the whole worktree**
+
+```bash
+cd .worktrees/removed-player-fix
+flutter analyze
+```
+Expected: no new issues.
+
+- [ ] **Step 5.2: Commit**
+
+```bash
+cd .worktrees/removed-player-fix
+git add lib/screens/cricket_game_screen.dart \
+        lib/screens/game_screen.dart \
+        lib/screens/around_the_clock_game_screen.dart \
+        test/screens/removed_player_winner_test.dart
+git commit -m "fix(cricket,x01,atc): removed mid-game player no longer becomes winner
+
+Add private helper _winnerIndexExcludingRemoved() that walks finishedPlayers
+and returns the first index not in _removedPlayerIndices. Replace all
+finishedPlayers.first-based winner picks (and downstream stats checks that
+match by index) with the helper.
+
+Removed players continue to be added to finishedPlayers so the ~70 existing
+finishedPlayers.contains(i) sites used as 'is this player still playing?'
+guards stay correct. The fix is intentionally minimal — full audit of those
+guards is deferred to a follow-up if QA finds post-game ranking misbehaviour.
+
+Killer and Shanghai use different winner patterns (isEliminated array /
+engine-based) and are not affected. Halve It uses highest-score; verified
+no change needed.
+
+Adds removed_player_winner_test.dart with one test per affected mode using
+@visibleForTesting hooks (removePlayerForTest, computeWinnerForTest).
+
+Spec: docs/superpowers/specs/2026-05-13-removed-player-winner-fix-design.md"
+```
+
+- [ ] **Step 5.3: Push and open PR (controller handles)**
+
+---
+
+## Self-review notes
+
+**Spec coverage:**
+- §Fix pattern → Tasks 1, 2, 3 ✓
+- §Round-skip logic for removed players → not needed for the minimal approach; `finishedPlayers` membership is preserved so existing skip logic still works ✓
+- §Halve It verification → covered as "verified, no change" in File map; no implementation task needed ✓
+- §Unit/widget tests → Task 4 ✓
+
+**Trade-off documented:** Plan goes with minimal-blast-radius approach instead of the spec's "drop finishedPlayers.add + audit 70 sites" approach. Rationale in Architecture section.
+
+**No placeholders.** Helper body is identical across all three files (DRY at the readability level even if duplicated as code — extracting to a shared mixin is overkill for 3 sites).
+
+**Type consistency:** Helper signature `int? _winnerIndexExcludingRemoved()` identical across all three files. Test hooks `removePlayerForTest(int)`, `computeWinnerForTest() → int?`, `finishedPlayersForTest → List<int>`, `removedPlayerIndicesForTest → Set<int>` identical across all three files.

--- a/docs/superpowers/plans/2026-05-13-shanghai-postgame-fixes-plan.md
+++ b/docs/superpowers/plans/2026-05-13-shanghai-postgame-fixes-plan.md
@@ -1,0 +1,327 @@
+# Shanghai post-game fixes — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix Shanghai post-game Undo (stats persist before user confirms) and add winner celebration (video + instant-Shanghai TTS) on game-end.
+
+**Architecture:** Single-file change in `lib/screens/shanghai_game_screen.dart`. Move `_updateStats(ranking)` out of `_onGameEnd` into the post-game action handler so stats only persist when user confirms Finish. Add `_fireWinnerCelebration` helper called from `_onGameEnd` to play winner video and (when `engine.isInstantShanghai`) announce "INSTANT SHANGHAI!".
+
+**Tech Stack:** Flutter (Dart), `flutter_test` widget tests, `VideoService.showRandomFromFolder('winner', context)`, `TtsService.instance.stop()` + `.speak()`.
+
+**Spec:** `docs/superpowers/specs/2026-05-13-shanghai-postgame-fixes-design.md` (commit `3941a8a`).
+
+**Discovered during planning:**
+- `Navigator.pushReplacement` is already gone — current code at `_showPostGame` (line 280) uses `Navigator.push<String>` with a `'undo'` handler that calls `engine.undo()`. Memo was 14 days old and partially out of date.
+- The remaining navigation gap is that `_updateStats(ranking)` (line 193) runs *before* `_showPostGame(ranking)` (line 195). Both fire from `_onGameEnd`. The fix is to move `_updateStats` into the `.then((action))` handler at line 287-296.
+- `VideoService.showRandomFromFolder` requires a `BuildContext` as its first argument — not omitted as the spec suggested.
+- `GameAnnouncer` has no `cancelAndSpeak` method. Call `TtsService.instance.stop()` followed by `TtsService.instance.speak(...)` directly (the `_ttsEnabled` flag this widget already uses gates whether to speak).
+
+---
+
+## File map
+
+**Modified:**
+- `lib/screens/shanghai_game_screen.dart` — `_onGameEnd`, `_showPostGame`, new `_fireWinnerCelebration` private method
+
+**Created:**
+- `test/screens/shanghai_postgame_undo_test.dart` — widget test for the Undo flow
+
+**No other files touched.**
+
+---
+
+## Task 1: Move `_updateStats` into post-game action handler
+
+**Files:**
+- Modify: `lib/screens/shanghai_game_screen.dart` (`_onGameEnd` around line 184-196, `_showPostGame` around line 262-297)
+
+- [ ] **Step 1.1: Update `_onGameEnd` to stop calling `_updateStats`**
+
+Replace the `_onGameEnd` method body (currently lines 184-196) with:
+
+```dart
+  Future<void> _onGameEnd() async {
+    final ranking = _rankPlayers();
+    _log.logGameEnd(
+      playerNames: players.map((p) => p.name).toList(),
+      finishedOrder: ranking,
+      gameFullyOver: true,
+    );
+    BatterySampler.instance.stop();
+    if (!mounted) return;
+    _showPostGame(ranking);
+  }
+```
+
+The `await _updateStats(ranking)` line is removed. `_updateStats` is still defined and used — Task 1.2 calls it from the post-game action handler instead.
+
+- [ ] **Step 1.2: Add `_updateStats` call in the post-game action handler**
+
+Find the `.then((action) { ... })` block in `_showPostGame` (currently lines 287-296). Replace its body with:
+
+```dart
+    ).then((action) async {
+      if (!mounted) return;
+      if (action == 'undo') {
+        // User wants to keep playing — undo the game-end and return to game.
+        setState(() => engine.undo());
+        return;
+      }
+      // 'home' or back-button: persist stats now (deferred from _onGameEnd
+      // so Undo doesn't strand the user with stats they didn't confirm),
+      // then leave the game-screen entirely.
+      await _updateStats(ranking);
+      if (!mounted) return;
+      Navigator.of(context).popUntil((route) => route.isFirst);
+    });
+```
+
+Two changes:
+- Callback becomes `async` so we can `await _updateStats(ranking)`.
+- `_updateStats(ranking)` is awaited inside the non-undo branch before `popUntil`.
+
+- [ ] **Step 1.3: Run analyzer**
+
+Run:
+```bash
+cd .worktrees/shanghai-fixes
+flutter analyze lib/screens/shanghai_game_screen.dart
+```
+Expected: no issues.
+
+- [ ] **Step 1.4: Do NOT commit yet**
+
+Task 2 lands the winner-celebration changes in the same logical commit.
+
+---
+
+## Task 2: Add winner celebration (video + instant-Shanghai TTS)
+
+**Files:**
+- Modify: `lib/screens/shanghai_game_screen.dart` (`_onGameEnd`, new private method `_fireWinnerCelebration`)
+
+- [ ] **Step 2.1: Add the helper method**
+
+Add this method to the `_ShanghaiGameScreenState` class, immediately after `_onGameEnd` (so around line 200, before `_updateStats`):
+
+```dart
+  Future<void> _fireWinnerCelebration() async {
+    if (engine.isInstantShanghai && _ttsEnabled) {
+      // High-priority announcement — stop any queued TTS so this lands first.
+      TtsService.instance.stop();
+      TtsService.instance.speak('INSTANT SHANGHAI!');
+    }
+    if (!mounted) return;
+    await VideoService.instance.showRandomFromFolder(context, 'winner');
+  }
+```
+
+Notes:
+- `_ttsEnabled` is the existing field this widget already checks (search the file for its declaration around the top of the state class to confirm it's in scope — it is used on line 168).
+- `VideoService.showRandomFromFolder` silently no-ops if the `winner` folder is empty or video events are disabled in settings, so no extra guard is needed.
+- The folder name `'winner'` is the same one other modes use.
+
+- [ ] **Step 2.2: Call the helper from `_onGameEnd`**
+
+Update `_onGameEnd` (rewritten in Task 1.1) to invoke the celebration before `_showPostGame`:
+
+```dart
+  Future<void> _onGameEnd() async {
+    final ranking = _rankPlayers();
+    _log.logGameEnd(
+      playerNames: players.map((p) => p.name).toList(),
+      finishedOrder: ranking,
+      gameFullyOver: true,
+    );
+    BatterySampler.instance.stop();
+    await _fireWinnerCelebration();
+    if (!mounted) return;
+    _showPostGame(ranking);
+  }
+```
+
+Only difference vs Task 1.1: the new `await _fireWinnerCelebration();` line before the `mounted` check.
+
+- [ ] **Step 2.3: Run analyzer**
+
+```bash
+cd .worktrees/shanghai-fixes
+flutter analyze lib/screens/shanghai_game_screen.dart
+```
+Expected: no issues.
+
+- [ ] **Step 2.4: Run existing test suite**
+
+```bash
+cd .worktrees/shanghai-fixes
+flutter test
+```
+Expected: all existing tests pass. No new test in this task — Task 3 adds the widget test.
+
+---
+
+## Task 3: Widget test for post-game Undo flow
+
+**Files:**
+- Create: `test/screens/shanghai_postgame_undo_test.dart`
+
+The Shanghai engine's game-end is driven by hitting all targets in the right pattern. Driving it from a widget test is unwieldy; instead this test:
+1. Mounts the screen,
+2. Drives the engine directly via the existing public API (using a small reflection-free helper inside the test that calls `_onHit` repeatedly through the widget's public surface, OR exposes the engine via a `@visibleForTesting` getter — see Step 3.1 below),
+3. Asserts `PostGameScreen` appears,
+4. Taps Undo,
+5. Asserts `ShanghaiGameScreen` is back and `engine.gameOver == false`.
+
+Stats persistence is verified indirectly: we assert that the back-and-forth doesn't crash and the engine state is restored. A full stats-side-effect assertion would require an injected `PlayerStorage` test double, which is out of scope for this fix — manual QA covers it.
+
+- [ ] **Step 3.1: Expose the engine for testing**
+
+Add a `@visibleForTesting` getter near the top of `_ShanghaiGameScreenState` in `lib/screens/shanghai_game_screen.dart` (place it just after the `engine` field declaration):
+
+```dart
+  @visibleForTesting
+  ShanghaiEngine get engineForTest => engine;
+```
+
+If `@visibleForTesting` is not already imported, add `import 'package:flutter/foundation.dart';` to the imports (the file may already have it via `material.dart` re-export — verify by running analyzer after the change; if not, add explicitly).
+
+- [ ] **Step 3.2: Write the test**
+
+Create `test/screens/shanghai_postgame_undo_test.dart` with:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dart_scoring/models/game_config.dart';
+import 'package:dart_scoring/models/player.dart';
+import 'package:dart_scoring/screens/shanghai_game_screen.dart';
+
+void main() {
+  testWidgets('post-game Undo returns to Shanghai screen with gameOver=false',
+      (tester) async {
+    final players = [
+      Player(name: 'P1', score: 0),
+      Player(name: 'P2', score: 0),
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      home: ShanghaiGameScreen(
+        players: players,
+        config: const ShanghaiConfig(targetEnd: 7),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // Find the state and drive the engine to game-over directly.
+    final state = tester.state<State<ShanghaiGameScreen>>(
+        find.byType(ShanghaiGameScreen));
+    // Cast through dynamic to reach the @visibleForTesting getter without
+    // exporting the private State type.
+    final dynamic dynState = state;
+    final engine = dynState.engineForTest;
+
+    // Trigger instant-Shanghai for P0: S+D+T on target 1 in one turn.
+    engine.recordThrow(/*HitType.single*/ 0);
+    engine.recordThrow(/*HitType.double_*/ 1);
+    engine.recordThrow(/*HitType.triple*/ 2);
+    // The screen's onHit listener fires _onGameEnd via setState; trigger
+    // a rebuild and let the post-screen Navigator.push complete.
+    dynState.setState(() {});
+    await tester.pumpAndSettle();
+
+    // PostGameScreen should now be visible.
+    expect(find.text('UNDO'), findsOneWidget,
+        reason: 'PostGameScreen with Undo button should be on top');
+
+    // Tap Undo and let navigation settle.
+    await tester.tap(find.text('UNDO'));
+    await tester.pumpAndSettle();
+
+    // Back in ShanghaiGameScreen — verify engine state was restored.
+    expect(find.byType(ShanghaiGameScreen), findsOneWidget);
+    expect(engine.gameOver, isFalse,
+        reason: 'engine.undo() should clear the game-over state');
+  });
+}
+```
+
+Important caveats this test makes explicit:
+- The `HitType` enum constants `single`, `double_`, `triple` are referenced as `0`, `1`, `2` only inside the comment — the test imports `HitType` from the engine and uses the real names. Replace the int placeholders by reading the enum declaration in `lib/services/shanghai_engine.dart` and adding `import 'package:dart_scoring/services/shanghai_engine.dart' show HitType;`, then writing `engine.recordThrow(HitType.single)` etc. Do this before running.
+- The `dynamic` cast is required because the State class is private. The `@visibleForTesting` getter is the public-by-convention escape hatch.
+- The test asserts the UNDO button text in caps — verify the actual button text in `lib/screens/post_game_screen.dart` and adjust if the casing differs.
+
+- [ ] **Step 3.3: Verify against the real `HitType` enum**
+
+Before running, open `lib/services/shanghai_engine.dart` and find the `HitType` enum. Replace the placeholder ints in the test with the real enum names. Add the import for `HitType` to the test file.
+
+- [ ] **Step 3.4: Verify the Undo button label**
+
+Open `lib/screens/post_game_screen.dart` and find the Undo button (search for `'undo'` and trace which Text widget it shows). If the visible label is not `UNDO` in all-caps, update the `find.text(...)` calls in Step 3.2 to match.
+
+- [ ] **Step 3.5: Run the new test**
+
+```bash
+cd .worktrees/shanghai-fixes
+flutter test test/screens/shanghai_postgame_undo_test.dart
+```
+Expected: PASS.
+
+If it fails on `find.text('UNDO')` not found, the post-game screen may not have rendered — re-check that the engine state-change actually triggers `_onGameEnd`. If `_onGameEnd` doesn't fire from `setState((){})` alone (because the listener is in `_onHit` and only fires when the engine just transitioned to `gameOver`), add an extra `recordThrow` of a no-op type or directly invoke `dynState.onGameEndForTest()` by exposing a `@visibleForTesting` method that wraps `_onGameEnd`. Prefer the second option — cleaner.
+
+- [ ] **Step 3.6: Run the full test suite**
+
+```bash
+cd .worktrees/shanghai-fixes
+flutter test
+```
+Expected: all tests pass.
+
+---
+
+## Task 4: Final analyzer + commit
+
+**Files:** none (verification + commit only)
+
+- [ ] **Step 4.1: Run analyzer over the whole worktree**
+
+```bash
+cd .worktrees/shanghai-fixes
+flutter analyze
+```
+Expected: no new issues introduced by the change.
+
+- [ ] **Step 4.2: Commit**
+
+```bash
+cd .worktrees/shanghai-fixes
+git add lib/screens/shanghai_game_screen.dart test/screens/shanghai_postgame_undo_test.dart
+git commit -m "fix(shanghai): post-game Undo preserves stats; add winner + instant-Shanghai triggers
+
+- Defer _updateStats(ranking) until user confirms Finish on post-game (was
+  running before post-game was shown, so Undo left stats already persisted)
+- Add VideoService.showRandomFromFolder(context, 'winner') on game-end
+- Add high-priority 'INSTANT SHANGHAI!' TTS when engine.isInstantShanghai
+- Expose engineForTest @visibleForTesting for widget test
+- Widget test: post-game Undo returns to ShanghaiGameScreen with gameOver=false
+
+Spec: docs/superpowers/specs/2026-05-13-shanghai-postgame-fixes-design.md"
+```
+
+- [ ] **Step 4.3: Push and open PR (separate task — done by controller, not the implementer)**
+
+The controller handles `git push -u origin fix/shanghai-postgame-undo-and-instant-trigger` and `gh pr create` after merge approval.
+
+---
+
+## Self-review notes
+
+**Spec coverage:**
+- §1 Navigation + stats flow (move `_updateStats` into action handler) → Task 1 ✓
+- §2 Winner celebration (video + instant-Shanghai TTS) → Task 2 ✓
+- §3 `engine.undo()` invariants → already verified by existing Undo handler at line 291 and engine code; explicit re-verification deferred to manual QA ✓ (acceptable per spec wording "verify during implementation")
+- §Widget test → Task 3 ✓
+
+**No placeholders.** All code shown; only the `HitType` enum names and Undo button label require a quick file lookup before running, which is explicit in Steps 3.3 and 3.4.
+
+**Type consistency:** `_fireWinnerCelebration` returns `Future<void>` consistently; `_onGameEnd` is `Future<void>` and `await`s it. `_updateStats(List<int> ranking)` signature unchanged.

--- a/docs/superpowers/specs/2026-05-13-removed-player-winner-fix-design.md
+++ b/docs/superpowers/specs/2026-05-13-removed-player-winner-fix-design.md
@@ -1,0 +1,129 @@
+# Removed mid-game player can win — design
+
+**Date:** 2026-05-13
+**Target branch:** `fix/removed-player-winner-index` (worktree `.worktrees/removed-player-fix`, branched from `main`)
+
+## Problem
+
+When a player is removed mid-game in Cricket, X01, or Around the Clock, their `playerIndex` is appended to both `_removedPlayerIndices` AND `finishedPlayers`. The winner is then computed as `winnerIndex = finishedPlayers.first` — so if a removed player's index landed first in the list, they are incorrectly declared the winner. Bug discovered 2026-05-12 in Cricket.
+
+Affected files (verified on `main` 2026-05-13):
+
+- `lib/screens/cricket_game_screen.dart` — remove handler at line 1230 (`_removedPlayerIndices.add`) + 1235 (`finishedPlayers.add`); winner picks at 142, 145, 373
+- `lib/screens/game_screen.dart` (X01) — remove handler at 1877 + 1884; winner picks at 725, 820, 914, 1056
+- `lib/screens/around_the_clock_game_screen.dart` — remove handler at 1354 + 1359; winner picks at 381, 424, 504, 727
+
+Not affected:
+
+- **Killer** — already filters via `isEliminated` + `!_removedPlayerIndices.contains(i)` checks
+- **Halve It / Splitscore** (`halve_it_game_screen.dart:1197`) — uses highest score for winner, not `finishedPlayers.first`. Verified during implementation by reading the file's winner-picking logic; if confirmed, no change. If touching `_removedPlayerIndices` still affects an "all-finished" condition, fix in this PR.
+- **Shanghai** — different winner pattern entirely (engine-based). Verified during implementation; no expected change.
+
+## Goals
+
+- Removed players are never declared the winner.
+- `winnerIndex = finishedPlayers.first` becomes correct by construction (removed players are not in `finishedPlayers` at all).
+- "All players finished" detection still works after the change.
+
+## Non-goals
+
+- Refactoring the mid-game-remove UI or storage
+- Touching Killer or Shanghai
+- Cleaning up the unrelated "winner picks" code paths beyond what the bug requires
+
+## Design
+
+### Fix pattern (applied to all three game screens)
+
+**Remove handler** — drop the `finishedPlayers.add(playerIndex)` line. Keep `_removedPlayerIndices.add(playerIndex)`. The removed player is tracked in `_removedPlayerIndices` only.
+
+Before (Cricket example, line 1230-1235):
+```dart
+_removedPlayerIndices.add(playerIndex);
+// ...
+finishedPlayers.add(playerIndex);   // ← drop this
+```
+
+After:
+```dart
+_removedPlayerIndices.add(playerIndex);
+// ...
+```
+
+**"All finished" checks** — every comparison like `finishedPlayers.length >= players.length - 1` (or any variant using `finishedPlayers.length` as a stop condition) must include removed players in the count:
+
+```dart
+finishedPlayers.length + _removedPlayerIndices.length >= players.length - 1
+```
+
+The implementation plan will enumerate every site per file via grep (search for `finishedPlayers.length` plus the `length` of `players` or `activePlayers`), update them, and add a code comment on the first one explaining the invariant.
+
+**Winner picks** — `winnerIndex = finishedPlayers.first` and `players[finishedPlayers.first]` stay as-is. They are correct once removed players are out of `finishedPlayers`.
+
+### Round-skip logic for removed players
+
+Removing a player from `finishedPlayers` may affect round-loop skip logic that historically piggybacked on the finished-list to skip removed players' turns. Each game-screen must instead check `_removedPlayerIndices.contains(i)` explicitly when iterating active players.
+
+The plan task list will:
+1. Grep each file for places that iterate `players` and check `!finishedPlayers.contains(i)` as a skip condition
+2. Add `&& !_removedPlayerIndices.contains(i)` where the intent was "skip players no longer playing"
+3. Leave alone the `finishedPlayers.contains(i)` checks whose intent is "skip players who already won"
+
+### Halve It verification
+
+Read `halve_it_game_screen.dart` winner-picking logic during implementation. Two possibilities:
+
+- **Halve It computes winner as `players.indexOf(highestScorePlayer)` ignoring `finishedPlayers`** — no fix needed beyond verifying.
+- **Halve It uses `finishedPlayers` indirectly** (e.g., for round termination) — apply the same `length + _removedPlayerIndices.length` fix to those checks.
+
+Document the finding in the PR description.
+
+## Verification
+
+### Unit/widget tests
+
+Three tests, one per affected mode. New file: `test/screens/removed_player_winner_test.dart`.
+
+Each test:
+1. Construct the game screen with 3 players (P0, P1, P2).
+2. Drive the game far enough that the mid-game remove UI is reachable (or invoke the remove handler directly through a test helper if exposed).
+3. Remove P0 mid-game.
+4. Drive P1 to win.
+5. Assert `winnerIndex == 1` and `players[winnerIndex].name == 'P1'`.
+6. Assert removed `_removedPlayerIndices == [0]` and `finishedPlayers` does NOT contain `0`.
+
+Cricket-specific: must reach the all-finished state from `winnerIndex` site at line 142/145.
+X01-specific: must reach checkout at line 820 site (or 914 for sudden-death variant).
+ATC-specific: must hit `winnerIndex = finishedPlayers.first` at line 424 or 504.
+
+If invoking the remove handler from a test requires UI tapping through a dialog, use `WidgetTester.tap` on the menu item. If it requires private-state access that tests can't reach, expose a `@visibleForTesting` setter or factor the handler into a testable helper.
+
+### Manual
+
+- 3-player Cricket: remove P0 mid-game, let P1 finish first → assert P1 is shown as winner on post-game.
+- Same for X01 and ATC.
+
+## Out of scope
+
+- Killer (already correct)
+- Shanghai (different pattern)
+- Stats-recording side effects beyond the `winnerIndex` consumer chain — the bug only affects who the winner is; downstream stats see the corrected value.
+
+## Commit plan
+
+Single commit on `fix/removed-player-winner-index`:
+
+```
+fix(cricket,x01,atc): removed mid-game player no longer becomes winner
+
+Drop finishedPlayers.add(playerIndex) in remove handlers — removed players
+are tracked only in _removedPlayerIndices. Update "all finished" checks to
+include _removedPlayerIndices.length so game-end detection still works.
+
+- Cricket: remove handler + 3 winner-pick sites + N all-finished checks
+- X01:     remove handler + 4 winner-pick sites + N all-finished checks
+- ATC:     remove handler + 4 winner-pick sites + N all-finished checks
+- Halve It: verified winner-picking is score-based; no change OR <fix details>
+
+Adds removed_player_winner_test.dart with one test per affected mode.
+```

--- a/docs/superpowers/specs/2026-05-13-shanghai-postgame-fixes-design.md
+++ b/docs/superpowers/specs/2026-05-13-shanghai-postgame-fixes-design.md
@@ -1,0 +1,132 @@
+# Shanghai post-game Undo + instant-Shanghai trigger — design
+
+**Date:** 2026-05-13
+**Target branch:** `fix/shanghai-postgame-undo-and-instant-trigger` (worktree `.worktrees/shanghai-fixes`, branched from `main`)
+
+## Problem
+
+Two issues in `lib/screens/shanghai_game_screen.dart`:
+
+1. **Post-game Undo resets the game.** When a Shanghai match ends, `_onGameEnd` calls `Navigator.pushReplacement(...)` to show `PostGameScreen` (removing `ShanghaiGameScreen` from the stack) and runs `await _updateStats(ranking)` *before* showing the post-game screen. If the user taps Undo on the post-game screen, the returned `'undo'` action pops out of the game flow entirely (no game-screen left under it), and stats have already been recorded — so even fixing the navigation alone would leave Elo/StatsRecorder/PlayerStorage out of sync.
+2. **No celebration trigger.** Shanghai has no video/meme on game-end winner or on instant Shanghai (S+D+T on the same target in one turn — a rare and spectacular event). Other game modes have winner video on game-end.
+
+## Goals
+
+- Post-game Undo returns to `ShanghaiGameScreen` with the last action rolled back, no stats persisted.
+- `_updateStats(ranking)` only runs after the user confirms Finish Game on the post-game screen.
+- Game-end fires `VideoService.showRandomFromFolder('winner')` to match other modes.
+- Instant-Shanghai (`engine.isInstantShanghai == true`) fires the same `'winner'` video PLUS a high-priority TTS announcement `"INSTANT SHANGHAI!"`.
+
+## Non-goals
+
+- New dedicated video folder for instant Shanghai (reuses existing `winner` folder per scope discussion).
+- High-round trigger (turn ≥ 100 in round 12+) mentioned in memo — deferred.
+- Touching other game screens.
+
+## Design
+
+### 1. Navigation + stats flow
+
+Replace the current `_onGameEnd` body to mirror X01's `game_screen.dart` push-and-await pattern:
+
+```dart
+Future<void> _onGameEnd(List<int> ranking) async {
+  // Fire celebration BEFORE showing post-game.
+  await _fireWinnerCelebration();
+
+  final action = await Navigator.push<String>(
+    context,
+    MaterialPageRoute(
+      builder: (_) => PostGameScreen(
+        players: players,
+        ranking: ranking,
+        // ...other args as today
+      ),
+    ),
+  );
+
+  if (!mounted) return;
+
+  if (action == 'undo') {
+    setState(() => engine.undo());
+    return;
+  }
+
+  // 'home' or null (back-button) — persist stats, then leave the screen.
+  await _updateStats(ranking);
+  if (!mounted) return;
+  Navigator.pop(context);
+}
+```
+
+`_updateStats(ranking)` keeps its current body but is no longer called inside `_onGameEnd` before navigation — it moves to the action handler.
+
+### 2. Winner celebration
+
+New private method:
+
+```dart
+Future<void> _fireWinnerCelebration() async {
+  if (engine.isInstantShanghai) {
+    // High-priority announcement; cancel queued TTS so this lands immediately.
+    await GameAnnouncer.instance.cancelAndSpeak('INSTANT SHANGHAI!');
+  }
+  await VideoService.instance.showRandomFromFolder('winner');
+}
+```
+
+`GameAnnouncer.cancelAndSpeak(...)` may need to be added to `lib/services/game_announcer.dart` if it doesn't already exist (verify during implementation — if it does, use it; if not, add a thin wrapper around `TtsService` that clears the queue first). The plan task list will check this.
+
+`VideoService.showRandomFromFolder('winner')` is the same call other modes use. If the folder is empty or the asset is missing, `VideoService` already silently no-ops — no extra guard needed.
+
+### 3. `engine.undo()` invariants
+
+Per memo, `engine.undo()` already restores `gameOver`, `winnerIndex`, and `isInstantShanghai`. Verify during implementation by reading `lib/services/shanghai_engine.dart` — if any of those don't reset, fix in the same PR.
+
+## Verification
+
+### Widget test
+
+`test/screens/shanghai_postgame_undo_test.dart`:
+
+1. Pump `ShanghaiGameScreen` with 2 players.
+2. Drive engine to game-over (call the public API that advances throws, or mock the engine to fast-forward).
+3. Assert `PostGameScreen` is in the tree.
+4. Tap the Undo button on `PostGameScreen` (find by text `'UNDO'` or the equivalent).
+5. Assert:
+   - `ShanghaiGameScreen` is back in the tree
+   - `engine.gameOver == false`
+   - `StatsRecorder.instance.gamesRecorded` (or equivalent counter) has not incremented since before the action
+6. Tap the Finish button.
+7. Assert:
+   - Stats counter has incremented now
+   - `Navigator.pop` was called (screen leaves)
+
+If `StatsRecorder` doesn't expose a counter for tests, use an injected/spy stats recorder or check the underlying `SharedPreferences` keys.
+
+### Manual
+
+- Play a Shanghai match to instant-Shanghai (S+D+T on round 1) → verify: `INSTANT SHANGHAI!` TTS, winner video plays
+- Play to last-round game-end → verify: winner video plays
+- On post-game, tap Undo → verify: back in Shanghai screen, last throw rolled back, stats unchanged
+- Tap Finish → verify: stats persisted, returned to home
+
+## Out of scope
+
+- High-round (≥100) trigger
+- Dedicated `instant_shanghai` video folder
+- Similar `pushReplacement`-pattern audit in other game screens (Halve It etc.) — flagged for a follow-up if QA finds them
+
+## Commit plan
+
+Single commit on `fix/shanghai-postgame-undo-and-instant-trigger`:
+
+```
+fix(shanghai): post-game Undo restores game state; add winner + instant-Shanghai triggers
+
+- Switch _onGameEnd to Navigator.push + await pattern (matches X01)
+- Move _updateStats out of _onGameEnd into post-Finish action handler
+- Add VideoService.showRandomFromFolder('winner') on game-end
+- Add high-priority "INSTANT SHANGHAI!" TTS + winner video on engine.isInstantShanghai
+- Widget test: post-game Undo returns to game with state intact and no stats persisted
+```

--- a/lib/screens/around_the_clock_game_screen.dart
+++ b/lib/screens/around_the_clock_game_screen.dart
@@ -74,6 +74,39 @@ class _AroundTheClockGameScreenState extends State<AroundTheClockGameScreen> {
   final Set<String> _leftMidGameIds = {};
   final Set<int> _removedPlayerIndices = {};
 
+  /// First player in [finishedPlayers] who has not been removed mid-game.
+  /// Used for winner picking — a removed player must never be declared winner
+  /// even if their index happens to appear first in [finishedPlayers].
+  int? _winnerIndexExcludingRemoved() {
+    for (final i in finishedPlayers) {
+      if (!_removedPlayerIndices.contains(i)) return i;
+    }
+    return null;
+  }
+
+  @visibleForTesting
+  List<int> get finishedPlayersForTest => finishedPlayers;
+
+  @visibleForTesting
+  Set<int> get removedPlayerIndicesForTest => _removedPlayerIndices;
+
+  @visibleForTesting
+  int? get winnerIndexForTest => winnerIndex;
+
+  @visibleForTesting
+  int? computeWinnerForTest() => _winnerIndexExcludingRemoved();
+
+  @visibleForTesting
+  void removePlayerForTest(int playerIndex) {
+    setState(() {
+      _midGamePlayerChanges = true;
+      _removedPlayerIndices.add(playerIndex);
+      if (!finishedPlayers.contains(playerIndex)) {
+        finishedPlayers.add(playerIndex);
+      }
+    });
+  }
+
   bool get _isReverse => widget.config.reverse;
   int get _maxTarget => widget.config.includeBull ? 25 : 20;
   int get _startTarget => _isReverse ? (_maxTarget == 25 ? 25 : 20) : 1;
@@ -378,7 +411,7 @@ class _AroundTheClockGameScreenState extends State<AroundTheClockGameScreen> {
         setState(() {
           if (activePlayers.length == 1) finishedPlayers.add(activePlayers.first);
           _gameFullyOver = true;
-          winnerIndex = finishedPlayers.isNotEmpty ? finishedPlayers.first : null;
+          winnerIndex = _winnerIndexExcludingRemoved();
         });
         _updateStats().then((_) => _showPostGame());
         return;
@@ -421,7 +454,7 @@ class _AroundTheClockGameScreenState extends State<AroundTheClockGameScreen> {
         .toList();
 
     setState(() {
-      winnerIndex = finishedPlayers.first;
+      winnerIndex = _winnerIndexExcludingRemoved() ?? finishedPlayers.first;
       _pendingFinishes.clear();
       _roundNumber++;
       _playersCompletedThisRound = {};
@@ -501,7 +534,7 @@ class _AroundTheClockGameScreenState extends State<AroundTheClockGameScreen> {
         finishedPlayers.add(pi);
       }
 
-      winnerIndex = finishedPlayers.first;
+      winnerIndex = _winnerIndexExcludingRemoved() ?? finishedPlayers.first;
       _suddenDeathPlayers.clear();
       _pendingFinishes.clear();
       _playersCompletedThisRound = {};
@@ -724,7 +757,7 @@ class _AroundTheClockGameScreenState extends State<AroundTheClockGameScreen> {
         _suddenDeathPlayers.clear();
       }
 
-      winnerIndex = finishedPlayers.isNotEmpty ? finishedPlayers.first : null;
+      winnerIndex = _winnerIndexExcludingRemoved();
       currentPlayerIndex = last.playerIndex;
       currentTargets[currentPlayerIndex] = last.scoreBefore;
       players[currentPlayerIndex].score = last.scoreBefore;
@@ -794,7 +827,7 @@ class _AroundTheClockGameScreenState extends State<AroundTheClockGameScreen> {
       if (idx < 0) continue;
       final sp = savedPlayers[idx];
       sp.gamesPlayed++;
-      if (finishedPlayers.isNotEmpty && finishedPlayers.first == pi) sp.gamesWon++;
+      if (_winnerIndexExcludingRemoved() == pi) sp.gamesWon++;
     }
 
     // Build placements from finishedPlayers order, then rank remaining by progress

--- a/lib/screens/cricket_game_screen.dart
+++ b/lib/screens/cricket_game_screen.dart
@@ -139,10 +139,10 @@ class _CricketGameScreenState extends State<CricketGameScreen> {
               .toList();
           if (activePlayers.length <= 1) {
             if (activePlayers.length == 1) finishedPlayers.add(activePlayers.first);
-            winnerIndex = finishedPlayers.first;
+            winnerIndex = _winnerIndexExcludingRemoved() ?? finishedPlayers.first;
             _gameFullyOver = true;
           } else {
-            winnerIndex = finishedPlayers.first;
+            winnerIndex = _winnerIndexExcludingRemoved() ?? finishedPlayers.first;
           }
           return;
         }
@@ -370,7 +370,7 @@ class _CricketGameScreenState extends State<CricketGameScreen> {
         scores[i] = data.scoresBefore[i];
         players[i].score = scores[i];
       }
-      winnerIndex = finishedPlayers.isNotEmpty ? finishedPlayers.first : null;
+      winnerIndex = _winnerIndexExcludingRemoved();
       lastThrowLabel = null;
     });
     _log.logUndo(
@@ -389,6 +389,39 @@ class _CricketGameScreenState extends State<CricketGameScreen> {
   final Set<String> _joinedMidGameIds = {};
   final Set<String> _leftMidGameIds = {};
   final Set<int> _removedPlayerIndices = {};
+
+  /// First player in [finishedPlayers] who has not been removed mid-game.
+  /// Used for winner picking — a removed player must never be declared winner
+  /// even if their index happens to appear first in [finishedPlayers].
+  int? _winnerIndexExcludingRemoved() {
+    for (final i in finishedPlayers) {
+      if (!_removedPlayerIndices.contains(i)) return i;
+    }
+    return null;
+  }
+
+  @visibleForTesting
+  List<int> get finishedPlayersForTest => finishedPlayers;
+
+  @visibleForTesting
+  Set<int> get removedPlayerIndicesForTest => _removedPlayerIndices;
+
+  @visibleForTesting
+  int? get winnerIndexForTest => winnerIndex;
+
+  @visibleForTesting
+  int? computeWinnerForTest() => _winnerIndexExcludingRemoved();
+
+  @visibleForTesting
+  void removePlayerForTest(int playerIndex) {
+    setState(() {
+      _midGamePlayerChanges = true;
+      _removedPlayerIndices.add(playerIndex);
+      if (!finishedPlayers.contains(playerIndex)) {
+        finishedPlayers.add(playerIndex);
+      }
+    });
+  }
 
   /// Computes final placements for all players.
   /// Finished players keep their finish order.

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -63,6 +63,40 @@ class _GameScreenState extends State<GameScreen> {
   final Set<String> _joinedMidGameIds = {};
   final Set<String> _leftMidGameIds = {};
   final Set<int> _removedPlayerIndices = {};
+
+  /// First player in [finishedPlayers] who has not been removed mid-game.
+  /// Used for winner picking — a removed player must never be declared winner
+  /// even if their index happens to appear first in [finishedPlayers].
+  int? _winnerIndexExcludingRemoved() {
+    for (final i in finishedPlayers) {
+      if (!_removedPlayerIndices.contains(i)) return i;
+    }
+    return null;
+  }
+
+  @visibleForTesting
+  List<int> get finishedPlayersForTest => finishedPlayers;
+
+  @visibleForTesting
+  Set<int> get removedPlayerIndicesForTest => _removedPlayerIndices;
+
+  @visibleForTesting
+  int? get winnerIndexForTest => winnerIndex;
+
+  @visibleForTesting
+  int? computeWinnerForTest() => _winnerIndexExcludingRemoved();
+
+  @visibleForTesting
+  void removePlayerForTest(int playerIndex) {
+    setState(() {
+      _midGamePlayerChanges = true;
+      _removedPlayerIndices.add(playerIndex);
+      if (!finishedPlayers.contains(playerIndex)) {
+        finishedPlayers.add(playerIndex);
+      }
+    });
+  }
+
   final ScrollController _scoreboardController = ScrollController();
   bool _soundEnabled = true;
   bool _ttsEnabled = false;
@@ -503,7 +537,7 @@ class _GameScreenState extends State<GameScreen> {
 
       final sp = savedPlayers[savedIndex];
       sp.gamesPlayed++;
-      if (finishedPlayers.isNotEmpty && finishedPlayers.first == pi) sp.gamesWon++;
+      if (_winnerIndexExcludingRemoved() == pi) sp.gamesWon++;
 
       // Calculate turn scores for this player
       final playerThrows =
@@ -722,7 +756,7 @@ class _GameScreenState extends State<GameScreen> {
         finishedPlayers
           ..clear()
           ..addAll(orderedFinishers);
-        winnerIndex = finishedPlayers.first;
+        winnerIndex = _winnerIndexExcludingRemoved() ?? finishedPlayers.first;
         _roundNumber++;
         _playersCompletedThisRound = {};
         _finishedBeforeRound = List.from(finishedPlayers);
@@ -735,7 +769,7 @@ class _GameScreenState extends State<GameScreen> {
       });
 
       if (_gameFullyOver) {
-        final winner = players[finishedPlayers.first];
+        final winner = players[_winnerIndexExcludingRemoved() ?? finishedPlayers.first];
         _log.logGameEnd(
             playerNames: players.map((p) => p.name).toList(),
             finishedOrder: finishedPlayers,
@@ -817,7 +851,7 @@ class _GameScreenState extends State<GameScreen> {
     _log.logResolve(roundNumber: _roundNumber, details: 'checkouts=[$checkoutSummary] finished=$finishedPlayers active=$activePlayers gameOver=${activePlayers.length <= 1}');
 
     setState(() {
-      winnerIndex = finishedPlayers.first;
+      winnerIndex = _winnerIndexExcludingRemoved() ?? finishedPlayers.first;
       _pendingCheckouts.clear();
       _roundNumber++;
       _playersCompletedThisRound = {};
@@ -833,7 +867,7 @@ class _GameScreenState extends State<GameScreen> {
 
     // Only announce winner and play victory sound when game is fully over
     if (_gameFullyOver) {
-      final winner = players[finishedPlayers.first];
+      final winner = players[_winnerIndexExcludingRemoved() ?? finishedPlayers.first];
       _log.logGameEnd(playerNames: players.map((p) => p.name).toList(), finishedOrder: finishedPlayers, gameFullyOver: true);
       BatterySampler.instance.stop();
       _announcer.stop();
@@ -911,7 +945,7 @@ class _GameScreenState extends State<GameScreen> {
         finishedPlayers.add(pi);
       }
 
-      winnerIndex = finishedPlayers.first;
+      winnerIndex = _winnerIndexExcludingRemoved() ?? finishedPlayers.first;
       _suddenDeathPlayers.clear();
       _pendingCheckouts.clear();
       _playersCompletedThisRound = {};
@@ -931,7 +965,7 @@ class _GameScreenState extends State<GameScreen> {
 
     // Only announce winner and play victory sound when game is fully over
     if (_gameFullyOver) {
-      final winner = players[finishedPlayers.first];
+      final winner = players[_winnerIndexExcludingRemoved() ?? finishedPlayers.first];
       _log.logGameEnd(playerNames: players.map((p) => p.name).toList(), finishedOrder: finishedPlayers, gameFullyOver: true);
       BatterySampler.instance.stop();
       _announcer.stop();
@@ -1053,7 +1087,7 @@ class _GameScreenState extends State<GameScreen> {
         _inSuddenDeath = false;
         _suddenDeathPlayers.clear();
       }
-      winnerIndex = finishedPlayers.isNotEmpty ? finishedPlayers.first : null;
+      winnerIndex = _winnerIndexExcludingRemoved();
       players[lastThrow.playerIndex].score = lastThrow.scoreBefore;
       currentPlayerIndex = lastThrow.playerIndex;
       dartsInTurn = lastThrow.turnNumber;
@@ -1897,9 +1931,7 @@ class _GameScreenState extends State<GameScreen> {
                   if (winnerIndex == null) {
                     winnerIndex = remaining.isNotEmpty
                         ? remaining.first
-                        : finishedPlayers.isNotEmpty
-                            ? finishedPlayers.first
-                            : 0;
+                        : _winnerIndexExcludingRemoved() ?? (finishedPlayers.isNotEmpty ? finishedPlayers.first : 0);
                   }
                   _gameFullyOver = true;
                 }

--- a/test/screens/removed_player_winner_test.dart
+++ b/test/screens/removed_player_winner_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dart_scoring/models/game_config.dart';
+import 'package:dart_scoring/models/player.dart';
+import 'package:dart_scoring/screens/cricket_game_screen.dart';
+import 'package:dart_scoring/screens/game_screen.dart';
+import 'package:dart_scoring/screens/around_the_clock_game_screen.dart';
+
+void main() {
+  testWidgets('Cricket: removed mid-game player does not become winner',
+      (tester) async {
+    final players = [
+      Player(name: 'P0', score: 0),
+      Player(name: 'P1', score: 0),
+      Player(name: 'P2', score: 0),
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      home: CricketGameScreen(
+        players: players,
+        config: const CricketConfig(
+          isRandom: false,
+          targetCount: 7,
+          includeBull: false,
+          isCutthroat: false,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final state = tester.state<State<CricketGameScreen>>(
+        find.byType(CricketGameScreen));
+    final dynamic dynState = state;
+
+    // Remove P0 mid-game — index 0 lands in both finishedPlayers and
+    // _removedPlayerIndices, mimicking the production handler.
+    dynState.removePlayerForTest(0);
+    await tester.pumpAndSettle();
+
+    expect(dynState.removedPlayerIndicesForTest.contains(0), isTrue);
+    expect(dynState.finishedPlayersForTest.first, equals(0),
+        reason: 'precondition: removed player must be first in finishedPlayers '
+            'for the bug to surface; the helper must skip them');
+
+    // Simulate P1 finishing — add to finishedPlayers second.
+    dynState.finishedPlayersForTest.add(1);
+
+    // Call the helper directly to verify it skips removed player.
+    final winner = dynState.computeWinnerForTest();
+    expect(winner, equals(1),
+        reason: 'P1 should be the winner — P0 was removed mid-game');
+  });
+
+  testWidgets('X01: removed mid-game player does not become winner',
+      (tester) async {
+    final players = [
+      Player(name: 'P0', score: 301),
+      Player(name: 'P1', score: 301),
+      Player(name: 'P2', score: 301),
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      home: GameScreen(
+        players: players,
+        startingScore: 301,
+        masterOut: 'none',
+        handicap: false,
+        noBust: false,
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final state =
+        tester.state<State<GameScreen>>(find.byType(GameScreen));
+    final dynamic dynState = state;
+
+    dynState.removePlayerForTest(0);
+    await tester.pumpAndSettle();
+
+    expect(dynState.removedPlayerIndicesForTest.contains(0), isTrue);
+    expect(dynState.finishedPlayersForTest.first, equals(0),
+        reason: 'precondition: removed player must be first in finishedPlayers '
+            'for the bug to surface; the helper must skip them');
+
+    dynState.finishedPlayersForTest.add(1);
+    final winner = dynState.computeWinnerForTest();
+    expect(winner, equals(1),
+        reason: 'P1 should be the winner — P0 was removed mid-game');
+  });
+
+  testWidgets('ATC: removed mid-game player does not become winner',
+      (tester) async {
+    final players = [
+      Player(name: 'P0', score: 0),
+      Player(name: 'P1', score: 0),
+      Player(name: 'P2', score: 0),
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      home: AroundTheClockGameScreen(
+        players: players,
+        config: const AroundTheClockConfig(
+          includeBull: false,
+          countMultiples: false,
+          reverse: false,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final state = tester.state<State<AroundTheClockGameScreen>>(
+        find.byType(AroundTheClockGameScreen));
+    final dynamic dynState = state;
+
+    dynState.removePlayerForTest(0);
+    await tester.pumpAndSettle();
+
+    expect(dynState.removedPlayerIndicesForTest.contains(0), isTrue);
+    expect(dynState.finishedPlayersForTest.first, equals(0),
+        reason: 'precondition: removed player must be first in finishedPlayers '
+            'for the bug to surface; the helper must skip them');
+
+    dynState.finishedPlayersForTest.add(1);
+    final winner = dynState.computeWinnerForTest();
+    expect(winner, equals(1),
+        reason: 'P1 should be the winner — P0 was removed mid-game');
+  });
+}


### PR DESCRIPTION
## Summary

Fixes a bug where a player removed mid-game in Cricket, X01, or Around the Clock could be declared the winner. Reported 2026-05-12 from a real Cricket session.

**Root cause:** When a player is removed mid-game, their `playerIndex` is added to both `_removedPlayerIndices` AND `finishedPlayers`. The winner is computed as `winnerIndex = finishedPlayers.first` — so if the removed player's index landed first, they incorrectly become the winner.

## Fix

Minimal-blast-radius approach: add a private helper `_winnerIndexExcludingRemoved()` per game screen that walks `finishedPlayers` in order and returns the first index not in `_removedPlayerIndices`. Replace all `finishedPlayers.first`-based winner picks (and downstream stats checks that match by index) with the helper.

Removed players continue to be added to `finishedPlayers` so the ~70 existing `finishedPlayers.contains(i)` sites used as "is this player still playing?" guards stay correct. A full audit of those guards (e.g., for post-game ranking) is deferred to a follow-up if QA finds misbehaviour.

## Files changed

- `lib/screens/cricket_game_screen.dart` — helper + 3 winner-pick sites
- `lib/screens/game_screen.dart` (X01) — helper + 9 winner-pick sites
- `lib/screens/around_the_clock_game_screen.dart` — helper + 5 winner-pick sites
- `test/screens/removed_player_winner_test.dart` — new, one regression test per affected mode

## Not affected

- **Killer** — already filters via `isEliminated` + `!_removedPlayerIndices.contains(i)`
- **Halve It / Splitscore** — winner is highest score, not `finishedPlayers.first`; verified
- **Shanghai** — engine-based winner pattern; not affected

## Test plan

- [x] `flutter analyze` — no new issues
- [x] `flutter test` — 160/160 passing (157 pre-existing + 3 new)
- [ ] Manual: 3-player Cricket, remove P0 mid-game, let P1 finish first → P1 shown as winner
- [ ] Manual: same for X01 and ATC

🤖 Generated with [Claude Code](https://claude.com/claude-code)
