### PR TITLE
Clean up 15 info-level lints + revert workflow guard

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,7 +22,7 @@ jobs:
           flutter-version: '3.41.8'
           cache: true
       - run: flutter pub get
-      - run: flutter analyze --no-fatal-infos
+      - run: flutter analyze
       - run: flutter test test/
 
   integration-tests:

--- a/lib/screens/around_the_clock_game_screen.dart
+++ b/lib/screens/around_the_clock_game_screen.dart
@@ -60,7 +60,7 @@ class _AroundTheClockGameScreenState extends State<AroundTheClockGameScreen> {
   int _roundNumber = 0;
   Set<int> _playersCompletedThisRound = {};
   List<int> _finishedBeforeRound = [];
-  List<_PendingFinish> _pendingFinishes = [];
+  final List<_PendingFinish> _pendingFinishes = [];
   List<int> _suddenDeathPlayers = [];
   bool _inSuddenDeath = false;
   int _consecutiveMisses = 0;

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -140,7 +140,7 @@ class _GameScreenState extends State<GameScreen> {
   int _roundNumber = 0;
   Set<int> _playersCompletedThisRound = {};
   List<int> _finishedBeforeRound = [];
-  List<_PendingCheckout> _pendingCheckouts = [];
+  final List<_PendingCheckout> _pendingCheckouts = [];
   List<int> _suddenDeathPlayers = [];
   bool _inSuddenDeath = false;
 
@@ -515,8 +515,11 @@ class _GameScreenState extends State<GameScreen> {
             isTurnEnd = true;
             // Turn-end video events
             final turnTotal = scoreAtStartOfTurn - player.score;
-            if (turnTotal >= 120) _pendingVideoEvent ??= 'high_round';
-            else if (turnTotal < 10) _pendingVideoEvent ??= 'low_round';
+            if (turnTotal >= 120) {
+              _pendingVideoEvent ??= 'high_round';
+            } else if (turnTotal < 10) {
+              _pendingVideoEvent ??= 'low_round';
+            }
             // Suppress meme sounds if video will play
             if (_pendingVideoEvent != null && videoRoll) _meme.markSoundPlayed();
             _meme.onTurnEnd();
@@ -529,10 +532,12 @@ class _GameScreenState extends State<GameScreen> {
 
     // Show video at turn end only (awaited so it doesn't get hidden)
     if (isTurnEnd && _pendingVideoEvent != null && videoRoll) {
+      if (!context.mounted) return;
+      // ignore: use_build_context_synchronously
       await VideoService.instance.showRandomFromFolder(context, _pendingVideoEvent!, chance: 1);
     }
     if (isTurnEnd) _pendingVideoEvent = null;
-    if (!mounted) return;
+    if (!context.mounted) return;
 
     // Check round completion after setState
     if (_isRoundComplete()) {
@@ -1959,11 +1964,9 @@ class _GameScreenState extends State<GameScreen> {
                     .where((i) => !finishedPlayers.contains(i))
                     .toList();
                 if (remaining.length <= 1) {
-                  if (winnerIndex == null) {
-                    winnerIndex = remaining.isNotEmpty
-                        ? remaining.first
-                        : _winnerIndexExcludingRemoved() ?? (finishedPlayers.isNotEmpty ? finishedPlayers.first : 0);
-                  }
+                  winnerIndex ??= remaining.isNotEmpty
+                      ? remaining.first
+                      : _winnerIndexExcludingRemoved() ?? (finishedPlayers.isNotEmpty ? finishedPlayers.first : 0);
                   _gameFullyOver = true;
                 }
               });

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -574,8 +574,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         value: _useDossedartDesign,
                         onChanged: (v) async {
                           await AppSettings.setUseDossedartDesign(v);
+                          if (!context.mounted) return;
                           setState(() => _useDossedartDesign = v);
-                          if (!mounted) return;
                           ScaffoldMessenger.of(context).showSnackBar(
                             const SnackBar(
                               content: Text('Restart the app to apply the new design.'),

--- a/lib/services/game_logger.dart
+++ b/lib/services/game_logger.dart
@@ -80,7 +80,7 @@ class GameLogger {
     if (!isGeneralAllowed) return;
     _gameIndex++;
     _write('');
-    _write('${'=' * 60}');
+    _write('=' * 60);
     _write('GAME #$_gameIndex: $gameMode | ${DateTime.now().toIso8601String()}');
     final players = <String>[];
     for (int i = 0; i < playerNames.length; i++) {
@@ -90,7 +90,7 @@ class GameLogger {
     if (config != null && config.isNotEmpty) {
       _write('Config: $config');
     }
-    _write('${'=' * 60}');
+    _write('=' * 60);
   }
 
   void logGameEnd({
@@ -103,7 +103,7 @@ class GameLogger {
         .map((i) => 'P$i:${i < playerNames.length ? playerNames[i] : '?'}')
         .join(', ');
     _write('GAME_END gameOver=$gameFullyOver placements=[$placements]');
-    _write('${'─' * 60}');
+    _write('─' * 60);
   }
 
   // ─── Turn events ────────────────────────────────────────────

--- a/lib/services/tts_service.dart
+++ b/lib/services/tts_service.dart
@@ -60,7 +60,9 @@ class TtsService {
       if (!_speaking) {
         final cbs = List<VoidCallback>.from(_idleCallbacks);
         _idleCallbacks.clear();
-        for (final cb in cbs) cb();
+        for (final cb in cbs) {
+          cb();
+        }
       }
     });
 

--- a/test/widgets/dossedart/dossedart_setup_scaffold_test.dart
+++ b/test/widgets/dossedart/dossedart_setup_scaffold_test.dart
@@ -23,7 +23,7 @@ Widget _harness({
   return MaterialApp(
     home: DossedartSetupScaffold(
       title: 'TEST',
-      rulesSection: (_, __) => const SizedBox.shrink(),
+      rulesSection: (_, _) => const SizedBox.shrink(),
       minPlayers: minPlayers,
       summaryBuilder: summaryBuilder,
       onStart: onStart,
@@ -36,7 +36,7 @@ void main() {
   // pumpAndSettle (it would hang). Instead, pump twice — once to render the
   // loading state, once after a small duration to let _load()'s async future
   // resolve.
-  Future<void> _settle(WidgetTester tester) async {
+  Future<void> settle(WidgetTester tester) async {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
   }
@@ -47,9 +47,9 @@ void main() {
     await tester.pumpWidget(_harness(
       minPlayers: 2,
       summaryBuilder: (_) => '',
-      onStart: (_, __) => called = true,
+      onStart: (_, _) => called = true,
     ));
-    await _settle(tester);
+    await settle(tester);
     await tester.tap(find.text('▶ START MATCH ◀'));
     await tester.pump();
     expect(called, isFalse);
@@ -60,9 +60,9 @@ void main() {
     await tester.pumpWidget(_harness(
       minPlayers: 2,
       summaryBuilder: (n) => '$n PLAYERS',
-      onStart: (_, __) {},
+      onStart: (_, _) {},
     ));
-    await _settle(tester);
+    await settle(tester);
     // CAST header shows MIN; we verify the cast header label.
     expect(find.text('0 READY · MIN 2'), findsOneWidget);
   });
@@ -79,7 +79,7 @@ void main() {
         randomized = r;
       },
     ));
-    await _settle(tester);
+    await settle(tester);
     // Tap Alice and Carol. Names render uppercased in tiles.
     await tester.tap(find.text('ALICE'));
     await tester.pump();


### PR DESCRIPTION
## Summary

Fixes all 15 info-level lints in the codebase and reverts the temporary
\`--no-fatal-infos\` workaround introduced in PR #6.

## What's fixed

- 2× \`prefer_final_fields\` (atc + game_screen)
- 3× \`curly_braces_in_flow_control_structures\` (game_screen × 2, tts)
- 1× \`prefer_conditional_assignment\` (game_screen winnerIndex)
- 3× \`unnecessary_string_interpolations\` (game_logger)
- 2× \`use_build_context_synchronously\` — properly guarded with
  \`context.mounted\` checks (one site requires an \`// ignore\` because
  the linter cannot see the guard through the awaited call)
- 3× \`unnecessary_underscores\` (test callback params)
- 1× \`no_leading_underscores_for_local_identifiers\` (test \`_settle\` → \`settle\`)

## Workflow change

\`flutter analyze --no-fatal-infos\` → \`flutter analyze\`. Future
info-lints will now fail CI immediately, surfacing drift early.

## Test plan

- [x] \`flutter analyze\` returns \"No issues found!\" locally
- [x] \`flutter test test/\` — 161 widget tests pass
- [ ] CI confirms widget + integration tests still green