### PR TITLE
DOSSEDART X01 cockpit + Player Overview (default state)

### DIFF
--- a/docs/design/dossedart-handoff/PROPOSAL-cockpit-v5.html
+++ b/docs/design/dossedart-handoff/PROPOSAL-cockpit-v5.html
@@ -1,0 +1,384 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>DOSSEDART — X01 cockpit v5 (CRT)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&display=swap" rel="stylesheet"/>
+<style>
+  :root {
+    --bg: #0a0014;
+    --surface: #1a0030;
+    --magenta: #FF00AA;
+    --cyan: #00E5FF;
+    --yellow: #FFD200;
+    --green: #3DFF8E;
+    --red: #FF3050;
+    --orange: #FF7A00;
+  }
+  body { margin: 0; background: #1a1714; font-family: 'Inter', system-ui, sans-serif; padding: 28px; }
+  .intro { max-width: 1100px; margin: 0 auto 24px; color: #e5e0d8; }
+  .intro h1 { font-family: 'Archivo', sans-serif; font-size: 32px; line-height: 1.05; letter-spacing: -1px; margin: 0 0 8px; font-weight: 900; }
+  .intro .kick { font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 2.5px; color: #ff9c75; text-transform: uppercase; font-weight: 600; margin-bottom: 8px; }
+  .intro p { font-size: 14px; line-height: 1.55; color: #b8b0a0; max-width: 900px; margin: 0 0 6px; }
+  .intro ul { font-size: 13px; line-height: 1.55; color: #b8b0a0; max-width: 900px; padding-left: 22px; }
+  .intro b { color: #e5e0d8; }
+  .stage { display: flex; gap: 32px; justify-content: center; flex-wrap: wrap; margin-top: 28px; }
+  .artboard-label { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: #b8b0a0; text-transform: uppercase; letter-spacing: 1.5px; margin-bottom: 8px; }
+
+  /* CRT cabinet bezel */
+  .crt {
+    width: 431px;            /* frame + bezel */
+    padding: 10px;
+    background: #2a2422;
+    border-radius: 24px;
+    box-shadow:
+      0 0 0 2px #1a1714,
+      0 12px 40px rgba(0,0,0,0.5),
+      inset 0 2px 6px rgba(255,255,255,0.08);
+  }
+
+  /* Inner glass — the screen itself */
+  .frame {
+    width: 411px; height: 731px;
+    background: var(--bg);
+    color: white;
+    position: relative;
+    overflow: hidden;
+    font-family: 'VT323', monospace;
+    border-radius: 16px;
+    /* Inner CRT-glass darkening at corners */
+    box-shadow:
+      inset 0 0 60px rgba(0,0,0,0.7),
+      inset 0 0 8px rgba(0,0,0,0.9);
+  }
+
+  /* Scanlines — stronger than before */
+  .frame::before {
+    content: ''; position: absolute; inset: 0;
+    background:
+      repeating-linear-gradient(0deg,
+        rgba(0,0,0,0) 0px,
+        rgba(0,0,0,0) 2px,
+        rgba(0,0,0,0.40) 3px,
+        rgba(0,0,0,0) 4px),
+      repeating-linear-gradient(90deg,
+        rgba(255,0,170,0.018) 0px,
+        rgba(0,229,255,0.018) 1px,
+        rgba(0,0,0,0) 2px,
+        rgba(0,0,0,0) 3px);
+    pointer-events: none; z-index: 2;
+  }
+  /* Vignette + phosphor screen-bulge */
+  .frame::after {
+    content: ''; position: absolute; inset: 0;
+    background: radial-gradient(ellipse at center, transparent 40%, rgba(0,0,0,0.75) 100%);
+    pointer-events: none; z-index: 3;
+    border-radius: 16px;
+  }
+
+  /* CRT power indicator — small dot bottom-right of bezel */
+  .crt-power {
+    position: absolute; right: 18px; bottom: 18px;
+    width: 6px; height: 6px;
+    background: var(--green);
+    border-radius: 50%;
+    box-shadow: 0 0 6px var(--green);
+    z-index: 10;
+  }
+  .crt-wrap { position: relative; }
+
+  .topbar {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 12px 14px; border-bottom: 2px solid var(--magenta);
+    background: black;
+    position: relative; z-index: 4;
+  }
+  .exit { font-family: 'VT323', monospace; font-size: 18px; color: var(--cyan); letter-spacing: 2px; flex: 0 0 auto;
+    text-shadow: 0 0 6px rgba(0,229,255,0.6), 1px 0 0 rgba(255,0,170,0.3), -1px 0 0 rgba(0,229,255,0.3);
+  }
+  .title { font-family: 'Press Start 2P', monospace; font-size: 11px; color: var(--yellow); letter-spacing: 2px;
+    text-shadow: 0 0 8px rgba(255,210,0,0.8), 1px 0 0 rgba(255,0,170,0.3), -1px 0 0 rgba(0,229,255,0.3);
+    flex: 1 1 auto; text-align: center; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .leg { font-family: 'VT323', monospace; font-size: 14px; color: rgba(255,255,255,0.55); letter-spacing: 2px; flex: 0 0 auto; }
+
+  .active-card {
+    margin: 12px 14px 10px; padding: 12px 14px;
+    border: 3px solid var(--magenta);
+    background: linear-gradient(180deg, rgba(255,0,170,0.10), rgba(255,0,170,0.02));
+    position: relative; z-index: 4;
+    box-shadow: 0 0 14px rgba(255,0,170,0.25);
+  }
+  .active-row { display: flex; align-items: center; gap: 12px; min-width: 0; }
+
+  /* Square avatar with player-color border */
+  .avatar-sq {
+    width: 56px; height: 56px;
+    background: #2a0050;
+    border: 3px solid var(--magenta);
+    flex: 0 0 auto;
+    box-shadow: 0 0 10px rgba(255,0,170,0.5);
+    display: flex; align-items: center; justify-content: center;
+    overflow: hidden;
+  }
+  .avatar-sq svg { width: 40px; height: 40px; opacity: 0.85; }
+  /* Profile pic version: a placeholder colorful pixel-art block to look like a photo */
+  .avatar-sq.pic {
+    background: linear-gradient(135deg, #ff7a8a, #ffc785 50%, #d18860);
+  }
+
+  .name-col { display: flex; flex-direction: column; min-width: 0; flex: 1 1 auto; gap: 4px; }
+  .name {
+    font-family: 'Press Start 2P', monospace;
+    color: white; letter-spacing: 2px;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    font-size: 18px;
+    text-shadow: 0 0 6px rgba(255,255,255,0.4), 1px 0 0 rgba(255,0,170,0.4), -1px 0 0 rgba(0,229,255,0.4);
+  }
+  /* Dart-dots row */
+  .dots-row { display: flex; align-items: center; gap: 6px; }
+  .dot {
+    width: 9px; height: 9px;
+    border: 2px solid var(--magenta);
+    background: transparent;
+  }
+  .dot.filled {
+    background: var(--magenta);
+    box-shadow: 0 0 6px rgba(255,0,170,0.7);
+  }
+  .dots-caption {
+    font-family: 'VT323', monospace; font-size: 13px;
+    color: rgba(255,255,255,0.55); letter-spacing: 1px;
+    margin-left: 6px;
+  }
+
+  .remaining-row { display: flex; align-items: baseline; justify-content: space-between; margin-top: 14px; }
+  .remaining-label { font-family: 'Press Start 2P', monospace; font-size: 9px; color: rgba(255,255,255,0.7); letter-spacing: 1.5px; }
+  /* CRT chromatic aberration on big number */
+  .remaining-num {
+    font-family: 'Press Start 2P', monospace; font-size: 60px;
+    color: var(--magenta); letter-spacing: 2px; line-height: 1;
+    text-shadow:
+      0 0 16px rgba(255,0,170,0.7),
+      2px 0 0 rgba(255,0,170,0.6),
+      -2px 0 0 rgba(0,229,255,0.6),
+      0 1px 0 rgba(255,255,255,0.15);
+  }
+
+  .last-row {
+    display: flex; align-items: baseline; justify-content: space-between;
+    margin-top: 10px; padding-top: 8px;
+    border-top: 1px dashed rgba(255,0,170,0.4);
+    gap: 8px;
+  }
+  .last-label { font-family: 'Press Start 2P', monospace; font-size: 9px; color: rgba(255,255,255,0.7); letter-spacing: 1.5px; flex: 0 0 auto; }
+  .last-throws { font-family: 'VT323', monospace; font-size: 20px; color: var(--yellow); letter-spacing: 1.5px; flex: 1 1 auto; text-align: center;
+    text-shadow: 0 0 6px rgba(255,210,0,0.5);
+  }
+  .last-sum { font-family: 'Press Start 2P', monospace; font-size: 13px; color: var(--yellow); letter-spacing: 1px; text-shadow: 0 0 6px rgba(255,210,0,0.5); flex: 0 0 auto; }
+
+  .checkout-tip {
+    margin-top: 10px; padding: 6px 8px;
+    border: 2px dashed var(--green);
+    background: rgba(61,255,142,0.06);
+    font-family: 'Press Start 2P', monospace; font-size: 10px; color: var(--green);
+    letter-spacing: 1px; text-align: center;
+    box-shadow: 0 0 14px rgba(61,255,142,0.4);
+    text-shadow: 0 0 4px rgba(61,255,142,0.5);
+  }
+
+  .board-wrap {
+    position: absolute; left: 50%; bottom: 84px; transform: translateX(-50%);
+    z-index: 4;
+  }
+
+  .actionbar {
+    position: absolute; bottom: 0; left: 0; right: 0;
+    background: black; border-top: 2px solid var(--yellow);
+    display: flex; gap: 10px; padding: 12px 14px;
+    z-index: 5;
+    border-bottom-left-radius: 16px; border-bottom-right-radius: 16px;
+  }
+  .btn {
+    flex: 1; padding: 12px 0;
+    font-family: 'Press Start 2P', monospace; font-size: 11px; letter-spacing: 1.5px;
+    background: transparent; color: white;
+    text-align: center;
+    border: 2px solid var(--magenta);
+    text-shadow: 0 0 4px rgba(255,0,170,0.6);
+  }
+  .btn.primary {
+    flex: 2;
+    background: var(--orange); border-color: white; color: black;
+    box-shadow: 0 0 16px rgba(255,122,0,0.55);
+    text-shadow: none;
+  }
+  .btn.menu { border-color: var(--cyan); color: var(--cyan); text-shadow: 0 0 4px rgba(0,229,255,0.6); }
+</style>
+</head>
+<body>
+
+<div class="intro">
+  <div class="kick">Proposal v5 · 2026-05-20 · CRT + profile pics + dart-dots back</div>
+  <h1>X01 Cockpit V5 — full CRT treatment</h1>
+  <p>Endringer fra V4:</p>
+  <ul>
+    <li><b>Profilbilder</b> — firkantet avatar med player-color border. Fallback = silhouette (Icons.person), matcher eksisterende <code>PlayerAvatar</code></li>
+    <li><b>Dart-prikker</b> tilbake — 3 små prikker under navnet som viser fremgang i nåværende tur (○○○ → ●○○ → ●●○ → ●●●). Subtilt, lite plass.</li>
+    <li><b>CRT-bezel</b> rundt skjermen — grå plastramme, små runde hjørner, power-LED nede i hjørnet</li>
+    <li><b>Sterkere scanlines</b> + horisontal RGB-fargestøy</li>
+    <li><b>Phosphor-glow</b> på all tekst — text-shadow på alle UI-elementer</li>
+    <li><b>Chromatic aberration</b> (RGB-ghost) på den store REMAINING-tallet og titler — klassisk CRT-feil</li>
+    <li><b>Inner glass-bulge</b> — inset shadows simulerer CRT-skjermens kurvatur</li>
+  </ul>
+  <p>To artboards: én med fallback-silhouette, én med "profile picture"-mockup (gradient som stedmark for ekte foto).</p>
+</div>
+
+<div class="stage">
+  <div>
+    <div class="artboard-label">Fallback silhouette avatar</div>
+    <div class="crt-wrap">
+      <div class="crt">
+        <div class="frame">
+          <div class="topbar">
+            <div class="exit">◀ EXIT</div>
+            <div class="title">X01 · 501 · D-OUT</div>
+            <div class="leg">L 1/3</div>
+          </div>
+          <div class="active-card">
+            <div class="active-row">
+              <div class="avatar-sq">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="white">
+                  <path d="M12 12c2.7 0 5-2.3 5-5s-2.3-5-5-5-5 2.3-5 5 2.3 5 5 5zm0 2c-3.3 0-10 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5z"/>
+                </svg>
+              </div>
+              <div class="name-col">
+                <div class="name">MIA</div>
+                <div class="dots-row">
+                  <div class="dot filled"></div>
+                  <div class="dot filled"></div>
+                  <div class="dot"></div>
+                  <div class="dots-caption">DART 3/3</div>
+                </div>
+              </div>
+            </div>
+            <div class="remaining-row">
+              <span class="remaining-label">REMAINING</span>
+              <span class="remaining-num">170</span>
+            </div>
+            <div class="last-row">
+              <span class="last-label">LAST</span>
+              <span class="last-throws">T20 · S20 · S20</span>
+              <span class="last-sum">= 80</span>
+            </div>
+            <div class="checkout-tip">▶ T20 › S16 › D-BULL</div>
+          </div>
+          <div class="board-wrap">
+            <svg width="320" height="320" viewBox="-220 -220 440 440">
+              <circle cx="0" cy="0" r="210" fill="#1a0030" stroke="#FF00AA" stroke-width="3"/>
+              <g class="segments"></g>
+              <circle cx="0" cy="0" r="22" fill="#FF7A00" stroke="white" stroke-width="2"/>
+              <circle cx="0" cy="0" r="10" fill="#FF3050" stroke="white" stroke-width="2"/>
+            </svg>
+          </div>
+          <div class="actionbar">
+            <div class="btn">↶ UNDO</div>
+            <div class="btn primary">✗ MISS</div>
+            <div class="btn menu">⋯ MENU</div>
+          </div>
+        </div>
+      </div>
+      <div class="crt-power"></div>
+    </div>
+  </div>
+
+  <div>
+    <div class="artboard-label">With profile picture</div>
+    <div class="crt-wrap">
+      <div class="crt">
+        <div class="frame">
+          <div class="topbar">
+            <div class="exit">◀ EXIT</div>
+            <div class="title">X01 · 501 · D-OUT</div>
+            <div class="leg">L 1/3</div>
+          </div>
+          <div class="active-card">
+            <div class="active-row">
+              <div class="avatar-sq pic"></div>
+              <div class="name-col">
+                <div class="name">BJØRN T.</div>
+                <div class="dots-row">
+                  <div class="dot filled"></div>
+                  <div class="dot"></div>
+                  <div class="dot"></div>
+                  <div class="dots-caption">DART 1/3</div>
+                </div>
+              </div>
+            </div>
+            <div class="remaining-row">
+              <span class="remaining-label">REMAINING</span>
+              <span class="remaining-num">268</span>
+            </div>
+            <div class="last-row">
+              <span class="last-label">LAST</span>
+              <span class="last-throws">S5 · S20 · S1</span>
+              <span class="last-sum">= 26</span>
+            </div>
+          </div>
+          <div class="board-wrap">
+            <svg width="320" height="320" viewBox="-220 -220 440 440">
+              <circle cx="0" cy="0" r="210" fill="#1a0030" stroke="#FF00AA" stroke-width="3"/>
+              <g class="segments"></g>
+              <circle cx="0" cy="0" r="22" fill="#FF7A00" stroke="white" stroke-width="2"/>
+              <circle cx="0" cy="0" r="10" fill="#FF3050" stroke="white" stroke-width="2"/>
+            </svg>
+          </div>
+          <div class="actionbar">
+            <div class="btn">↶ UNDO</div>
+            <div class="btn primary">✗ MISS</div>
+            <div class="btn menu">⋯ MENU</div>
+          </div>
+        </div>
+      </div>
+      <div class="crt-power"></div>
+    </div>
+  </div>
+</div>
+
+<script>
+const SEG_ORDER = [20, 1, 18, 4, 13, 6, 10, 15, 2, 17, 3, 19, 7, 16, 8, 11, 14, 9, 12, 5];
+const R = { bull: 22, triple: 110, outerSingle: 160, double: 178, edge: 210 };
+function arc(r1, r2, a1, a2) {
+  const toRad = a => (a - 90) * Math.PI / 180;
+  const p = (r, a) => [Math.cos(toRad(a)) * r, Math.sin(toRad(a)) * r];
+  const [x1, y1] = p(r2, a1);
+  const [x2, y2] = p(r2, a2);
+  const [x3, y3] = p(r1, a2);
+  const [x4, y4] = p(r1, a1);
+  const large = (a2 - a1) > 180 ? 1 : 0;
+  return `M ${x1} ${y1} A ${r2} ${r2} 0 ${large} 1 ${x2} ${y2} L ${x3} ${y3} A ${r1} ${r1} 0 ${large} 0 ${x4} ${y4} Z`;
+}
+document.querySelectorAll('.segments').forEach(g => {
+  const SLICE = 360 / 20;
+  for (let i = 0; i < 20; i++) {
+    const startAng = -SLICE / 2 + i * SLICE;
+    const endAng = startAng + SLICE;
+    const value = SEG_ORDER[i];
+    const innerCol = i % 2 === 0 ? '#FF00AA' : '#00E5FF';
+    g.innerHTML += `<path d="${arc(R.bull, R.triple, startAng, endAng)}" fill="${innerCol}" opacity="0.35" stroke="black" stroke-width="0.5"/>`;
+    g.innerHTML += `<path d="${arc(R.triple, 120, startAng, endAng)}" fill="#3DFF8E" stroke="black" stroke-width="0.5"/>`;
+    g.innerHTML += `<path d="${arc(120, R.outerSingle, startAng, endAng)}" fill="${innerCol}" opacity="0.35" stroke="black" stroke-width="0.5"/>`;
+    g.innerHTML += `<path d="${arc(R.outerSingle, R.double, startAng, endAng)}" fill="#FFD200" stroke="black" stroke-width="0.5"/>`;
+    g.innerHTML += `<path d="${arc(R.double, R.edge, startAng, endAng)}" fill="#0a0014" stroke="#FF00AA" stroke-width="0.5"/>`;
+    const midAng = (startAng + endAng) / 2;
+    const rad = (midAng - 90) * Math.PI / 180;
+    const lx = Math.cos(rad) * 195;
+    const ly = Math.sin(rad) * 195;
+    g.innerHTML += `<text x="${lx}" y="${ly}" fill="white" font-family="'Press Start 2P', monospace" font-size="11" text-anchor="middle" dominant-baseline="central">${value}</text>`;
+  }
+});
+</script>
+
+</body>
+</html>

--- a/docs/design/dossedart-handoff/PROPOSAL-cockpit-v5.html
+++ b/docs/design/dossedart-handoff/PROPOSAL-cockpit-v5.html
@@ -348,7 +348,9 @@
 
 <script>
 const SEG_ORDER = [20, 1, 18, 4, 13, 6, 10, 15, 2, 17, 3, 19, 7, 16, 8, 11, 14, 9, 12, 5];
-const R = { bull: 22, triple: 110, outerSingle: 160, double: 178, edge: 210 };
+// Visual = hit-test: thicker rings than a real board so what you see is what you can tap.
+// Radii as % of board radius (210): bullIn 5%, bull 12%, innerSingle 47%, triple 58%, outerSingle 82%, double 95%, labelBand 100%
+const R = { bullIn: 10, bull: 25, innerSingle: 99, triple: 122, outerSingle: 172, double: 200, edge: 210 };
 function arc(r1, r2, a1, a2) {
   const toRad = a => (a - 90) * Math.PI / 180;
   const p = (r, a) => [Math.cos(toRad(a)) * r, Math.sin(toRad(a)) * r];
@@ -366,16 +368,21 @@ document.querySelectorAll('.segments').forEach(g => {
     const endAng = startAng + SLICE;
     const value = SEG_ORDER[i];
     const innerCol = i % 2 === 0 ? '#FF00AA' : '#00E5FF';
-    g.innerHTML += `<path d="${arc(R.bull, R.triple, startAng, endAng)}" fill="${innerCol}" opacity="0.35" stroke="black" stroke-width="0.5"/>`;
-    g.innerHTML += `<path d="${arc(R.triple, 120, startAng, endAng)}" fill="#3DFF8E" stroke="black" stroke-width="0.5"/>`;
-    g.innerHTML += `<path d="${arc(120, R.outerSingle, startAng, endAng)}" fill="${innerCol}" opacity="0.35" stroke="black" stroke-width="0.5"/>`;
+    // Inner single (12% → 47%)
+    g.innerHTML += `<path d="${arc(R.bull, R.innerSingle, startAng, endAng)}" fill="${innerCol}" opacity="0.35" stroke="black" stroke-width="0.5"/>`;
+    // Triple ring (47% → 58%) — thick, green
+    g.innerHTML += `<path d="${arc(R.innerSingle, R.triple, startAng, endAng)}" fill="#3DFF8E" stroke="black" stroke-width="0.5"/>`;
+    // Outer single (58% → 82%)
+    g.innerHTML += `<path d="${arc(R.triple, R.outerSingle, startAng, endAng)}" fill="${innerCol}" opacity="0.35" stroke="black" stroke-width="0.5"/>`;
+    // Double ring (82% → 95%) — thick, yellow
     g.innerHTML += `<path d="${arc(R.outerSingle, R.double, startAng, endAng)}" fill="#FFD200" stroke="black" stroke-width="0.5"/>`;
+    // Outer label band (95% → 100%) — non-tappable, miss zone
     g.innerHTML += `<path d="${arc(R.double, R.edge, startAng, endAng)}" fill="#0a0014" stroke="#FF00AA" stroke-width="0.5"/>`;
     const midAng = (startAng + endAng) / 2;
     const rad = (midAng - 90) * Math.PI / 180;
-    const lx = Math.cos(rad) * 195;
-    const ly = Math.sin(rad) * 195;
-    g.innerHTML += `<text x="${lx}" y="${ly}" fill="white" font-family="'Press Start 2P', monospace" font-size="11" text-anchor="middle" dominant-baseline="central">${value}</text>`;
+    const lx = Math.cos(rad) * 205;
+    const ly = Math.sin(rad) * 205;
+    g.innerHTML += `<text x="${lx}" y="${ly}" fill="white" font-family="'Press Start 2P', monospace" font-size="10" text-anchor="middle" dominant-baseline="central">${value}</text>`;
   }
 });
 </script>

--- a/docs/design/dossedart-handoff/PROPOSAL-player-overview-v4.html
+++ b/docs/design/dossedart-handoff/PROPOSAL-player-overview-v4.html
@@ -1,0 +1,350 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>DOSSEDART — Player Overview v4 (CRT + photos)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&display=swap" rel="stylesheet"/>
+<style>
+  :root {
+    --bg: #0a0014;
+    --magenta: #FF00AA;
+    --cyan: #00E5FF;
+    --yellow: #FFD200;
+    --green: #3DFF8E;
+    --red: #FF3050;
+  }
+  body { margin: 0; background: #1a1714; font-family: 'Inter', system-ui, sans-serif; padding: 28px; }
+  .intro { max-width: 1100px; margin: 0 auto 24px; color: #e5e0d8; }
+  .intro h1 { font-family: 'Archivo', sans-serif; font-size: 32px; line-height: 1.05; letter-spacing: -1px; margin: 0 0 8px; font-weight: 900; }
+  .intro .kick { font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 2.5px; color: #ff9c75; text-transform: uppercase; font-weight: 600; margin-bottom: 8px; }
+  .intro p { font-size: 14px; line-height: 1.55; color: #b8b0a0; max-width: 900px; margin: 0 0 6px; }
+  .intro ul { font-size: 13px; line-height: 1.55; color: #b8b0a0; max-width: 900px; padding-left: 22px; }
+  .intro b { color: #e5e0d8; }
+  .stage { display: flex; gap: 32px; justify-content: center; flex-wrap: wrap; margin-top: 28px; }
+  .artboard-label { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: #b8b0a0; text-transform: uppercase; letter-spacing: 1.5px; margin-bottom: 8px; }
+
+  .crt {
+    width: 431px;
+    padding: 10px;
+    background: #2a2422;
+    border-radius: 24px;
+    box-shadow:
+      0 0 0 2px #1a1714,
+      0 12px 40px rgba(0,0,0,0.5),
+      inset 0 2px 6px rgba(255,255,255,0.08);
+  }
+  .frame {
+    width: 411px; height: 731px;
+    background: var(--bg);
+    color: white;
+    position: relative;
+    overflow: hidden;
+    font-family: 'VT323', monospace;
+    border-radius: 16px;
+    box-shadow:
+      inset 0 0 60px rgba(0,0,0,0.7),
+      inset 0 0 8px rgba(0,0,0,0.9);
+  }
+  .frame::before {
+    content: ''; position: absolute; inset: 0;
+    background:
+      repeating-linear-gradient(0deg,
+        rgba(0,0,0,0) 0px,
+        rgba(0,0,0,0) 2px,
+        rgba(0,0,0,0.40) 3px,
+        rgba(0,0,0,0) 4px),
+      repeating-linear-gradient(90deg,
+        rgba(255,0,170,0.018) 0px,
+        rgba(0,229,255,0.018) 1px,
+        rgba(0,0,0,0) 2px,
+        rgba(0,0,0,0) 3px);
+    pointer-events: none; z-index: 2;
+  }
+  .frame::after {
+    content: ''; position: absolute; inset: 0;
+    background: radial-gradient(ellipse at center, transparent 40%, rgba(0,0,0,0.75) 100%);
+    pointer-events: none; z-index: 3;
+    border-radius: 16px;
+  }
+  .crt-power {
+    position: absolute; right: 18px; bottom: 18px;
+    width: 6px; height: 6px;
+    background: var(--green);
+    border-radius: 50%;
+    box-shadow: 0 0 6px var(--green);
+    z-index: 10;
+  }
+  .crt-wrap { position: relative; }
+
+  .topbar {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 12px 14px;
+    border-bottom: 2px solid var(--magenta);
+    background: black;
+    position: relative; z-index: 4;
+  }
+  .back { font-family: 'VT323', monospace; font-size: 18px; color: var(--cyan); letter-spacing: 2px;
+    text-shadow: 0 0 6px rgba(0,229,255,0.6), 1px 0 0 rgba(255,0,170,0.3), -1px 0 0 rgba(0,229,255,0.3); }
+  .title {
+    font-family: 'Press Start 2P', monospace; font-size: 11px;
+    color: var(--yellow); letter-spacing: 2px;
+    text-shadow: 0 0 8px rgba(255,210,0,0.8), 1px 0 0 rgba(255,0,170,0.3), -1px 0 0 rgba(0,229,255,0.3);
+  }
+  .round { font-family: 'VT323', monospace; font-size: 14px; color: rgba(255,255,255,0.55); letter-spacing: 2px; }
+
+  .marquee {
+    text-align: center; padding: 10px 0;
+    font-family: 'Press Start 2P', monospace; font-size: 12px;
+    color: var(--magenta); letter-spacing: 4px;
+    text-shadow:
+      0 0 8px rgba(255,0,170,0.7),
+      2px 0 0 rgba(255,0,170,0.4),
+      -2px 0 0 rgba(0,229,255,0.4);
+    border-bottom: 1px dashed rgba(255,0,170,0.4);
+    background: rgba(0,0,0,0.4);
+    position: relative; z-index: 4;
+  }
+
+  .col-header {
+    display: grid;
+    grid-template-columns: 32px 44px 1fr auto;
+    gap: 10px;
+    padding: 8px 18px 6px;
+    font-family: 'Press Start 2P', monospace; font-size: 8px;
+    color: var(--cyan); letter-spacing: 1.5px;
+    text-shadow: 0 0 4px rgba(0,229,255,0.5);
+    border-bottom: 1px solid rgba(0,229,255,0.3);
+    position: relative; z-index: 4;
+  }
+
+  .list {
+    padding: 6px 14px 14px;
+    position: relative; z-index: 4;
+    max-height: calc(731px - 49px - 36px - 30px - 28px);
+    overflow-y: auto;
+  }
+
+  .row {
+    padding: 10px 4px 12px;
+    border-bottom: 1px dashed rgba(255,255,255,0.18);
+  }
+  .row:last-child { border-bottom: none; }
+
+  .row-line1 {
+    display: grid;
+    grid-template-columns: 32px 44px 1fr auto;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+  .rank {
+    font-family: 'Press Start 2P', monospace; font-size: 16px;
+    color: var(--yellow); letter-spacing: 1px;
+    text-shadow: 0 0 6px rgba(255,210,0,0.5);
+  }
+  /* Square avatar for overview */
+  .av {
+    width: 44px; height: 44px;
+    background: #2a0050;
+    border: 2px solid var(--magenta);
+    display: flex; align-items: center; justify-content: center;
+    overflow: hidden;
+    box-shadow: 0 0 6px rgba(255,0,170,0.4);
+  }
+  .av svg { width: 28px; height: 28px; opacity: 0.85; }
+  .av.pic.a { background: linear-gradient(135deg, #ff7a8a, #ffc785 50%, #d18860); }
+  .av.pic.b { background: linear-gradient(135deg, #6e9bff, #b5d6ff 50%, #7d8aa3); }
+
+  .name {
+    font-family: 'Press Start 2P', monospace;
+    color: white; letter-spacing: 2px;
+    min-width: 0;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    font-size: 14px;
+    text-shadow: 0 0 6px rgba(255,255,255,0.3), 1px 0 0 rgba(255,0,170,0.4), -1px 0 0 rgba(0,229,255,0.4);
+  }
+  .name.medium { font-size: 12px; letter-spacing: 1.5px; }
+  .name.long { font-size: 10px; letter-spacing: 1.2px; }
+  .remaining {
+    font-family: 'Press Start 2P', monospace; font-size: 26px;
+    color: var(--magenta); letter-spacing: 1px; line-height: 1;
+    text-shadow:
+      0 0 10px rgba(255,0,170,0.7),
+      2px 0 0 rgba(255,0,170,0.5),
+      -2px 0 0 rgba(0,229,255,0.5);
+    text-align: right;
+    flex-shrink: 0;
+  }
+
+  .row-line2 {
+    margin-top: 8px;
+    padding-left: 88px;
+    display: flex; justify-content: space-between; align-items: baseline;
+    font-family: 'VT323', monospace; font-size: 16px;
+    color: rgba(255,255,255,0.75); letter-spacing: 1.5px;
+  }
+  .stats-mini { color: rgba(255,255,255,0.55); }
+  .stats-mini b { color: var(--cyan); font-weight: normal; text-shadow: 0 0 4px rgba(0,229,255,0.5); }
+
+  .row-last {
+    margin-top: 8px;
+    padding: 8px 12px;
+    background: rgba(255,210,0,0.08);
+    border: 1.5px solid rgba(255,210,0,0.35);
+    display: flex; justify-content: space-between; align-items: baseline;
+    font-family: 'VT323', monospace; font-size: 22px; letter-spacing: 2px;
+    color: var(--yellow);
+    text-shadow: 0 0 6px rgba(255,210,0,0.6);
+    gap: 8px;
+  }
+  .row-last .label {
+    font-family: 'Press Start 2P', monospace; font-size: 8px;
+    color: rgba(255,210,0,0.65); letter-spacing: 1px;
+    flex-shrink: 0;
+  }
+  .row-last .sum {
+    font-family: 'Press Start 2P', monospace; font-size: 12px;
+    color: var(--yellow);
+    flex-shrink: 0;
+  }
+  .row-last .throws {
+    flex: 1; text-align: center;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+
+  .footer-marquee {
+    position: absolute; bottom: 0; left: 0; right: 0;
+    text-align: center; padding: 8px 0;
+    border-top: 1px dashed rgba(0,229,255,0.4);
+    background: black;
+    font-family: 'Press Start 2P', monospace; font-size: 9px;
+    color: var(--cyan); letter-spacing: 3px;
+    text-shadow: 0 0 6px rgba(0,229,255,0.6), 1px 0 0 rgba(255,0,170,0.3), -1px 0 0 rgba(0,229,255,0.3);
+    z-index: 5;
+    border-bottom-left-radius: 16px; border-bottom-right-radius: 16px;
+  }
+</style>
+</head>
+<body>
+
+<div class="intro">
+  <div class="kick">Proposal v4 · 2026-05-20 · CRT + profile pics</div>
+  <h1>Player Overview V4 — full CRT + photos</h1>
+  <p>Endringer fra V3:</p>
+  <ul>
+    <li><b>Profilbilder</b> i kvadratisk avatar med player-color border. Silhouette-fallback hvis ingen photo (matcher eksisterende PlayerAvatar)</li>
+    <li>CRT-bezel rundt skjermen, screen-bulge inset, sterkere scanlines med horisontal RGB-tint, phosphor-glow på all tekst, chromatic aberration på REMAINING + titler</li>
+  </ul>
+</div>
+
+<div class="stage">
+  <div>
+    <div class="artboard-label">Player Overview V4</div>
+    <div class="crt-wrap">
+      <div class="crt">
+        <div class="frame">
+          <div class="topbar">
+            <div class="back">◀ BACK</div>
+            <div class="title">CAST · X01 501</div>
+            <div class="round">RND 7</div>
+          </div>
+
+          <div class="marquee">► SCOREBOARD ◄</div>
+
+          <div class="col-header">
+            <span>#</span>
+            <span></span>
+            <span>PLAYER</span>
+            <span style="text-align:right">REMAIN</span>
+          </div>
+
+          <div class="list">
+            <div class="row">
+              <div class="row-line1">
+                <span class="rank">01</span>
+                <div class="av pic a"></div>
+                <span class="name">MIA</span>
+                <span class="remaining">170</span>
+              </div>
+              <div class="row-line2">
+                <span class="stats-mini">AVG <b>31.3</b> · HIT <b>87%</b></span>
+              </div>
+              <div class="row-last">
+                <span class="label">LAST</span>
+                <span class="throws">T20 · S20 · S20</span>
+                <span class="sum">80</span>
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="row-line1">
+                <span class="rank">02</span>
+                <div class="av pic b"></div>
+                <span class="name medium">BJØRN T.</span>
+                <span class="remaining">268</span>
+              </div>
+              <div class="row-line2">
+                <span class="stats-mini">AVG <b>24.7</b> · HIT <b>82%</b></span>
+              </div>
+              <div class="row-last">
+                <span class="label">LAST</span>
+                <span class="throws">S5 · S20 · S1</span>
+                <span class="sum">26</span>
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="row-line1">
+                <span class="rank">03</span>
+                <div class="av">
+                  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="white">
+                    <path d="M12 12c2.7 0 5-2.3 5-5s-2.3-5-5-5-5 2.3-5 5 2.3 5 5 5zm0 2c-3.3 0-10 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5z"/>
+                  </svg>
+                </div>
+                <span class="name long">BJØRN TORJUS</span>
+                <span class="remaining">421</span>
+              </div>
+              <div class="row-line2">
+                <span class="stats-mini">AVG <b>19.8</b> · HIT <b>76%</b></span>
+              </div>
+              <div class="row-last">
+                <span class="label">LAST</span>
+                <span class="throws">S20 · MISS · S5</span>
+                <span class="sum">25</span>
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="row-line1">
+                <span class="rank">04</span>
+                <div class="av">
+                  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="white">
+                    <path d="M12 12c2.7 0 5-2.3 5-5s-2.3-5-5-5-5 2.3-5 5 2.3 5 5 5zm0 2c-3.3 0-10 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5z"/>
+                  </svg>
+                </div>
+                <span class="name long">CHRISTOPHER A...</span>
+                <span class="remaining">501</span>
+              </div>
+              <div class="row-line2">
+                <span class="stats-mini">AVG <b>0.0</b> · HIT <b>--</b></span>
+              </div>
+              <div class="row-last">
+                <span class="label">LAST</span>
+                <span class="throws">— · — · —</span>
+                <span class="sum">0</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="footer-marquee">★ ★ ★ INSERT DART TO CONTINUE ★ ★ ★</div>
+        </div>
+      </div>
+      <div class="crt-power"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/docs/superpowers/plans/2026-05-20-dossedart-x01-cockpit-plan.md
+++ b/docs/superpowers/plans/2026-05-20-dossedart-x01-cockpit-plan.md
@@ -1,0 +1,2249 @@
+# DOSSEDART X01 Cockpit — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the DOSSEDART X01 in-game cockpit (default state) + a Player Overview screen, gated behind the existing `use_dossedart_design` preview flag.
+
+**Architecture:** `GameScreen.build()` branches on a new `useDossedartDesign` constructor param. The DOSSEDART branch composes new presentational widgets (CRT frame, topbar, active card, dartboard, action bar) over the unchanged `_GameScreenState` (logic shared with classic). Dartboard hit-test bands match visual ring widths exactly — no surprise misses.
+
+**Tech Stack:** Flutter (existing project), `CustomPainter` for the dartboard, `Stack`/`Positioned` for layout invariants, existing `Player`/`DartThrow` models, existing `_onDartHit`/`_onMiss`/`_undo` methods on `_GameScreenState`.
+
+**Spec:** `docs/superpowers/specs/2026-05-20-dossedart-x01-cockpit-design.md` (commits `431aff7`, `db73a14`, `892152b`).
+**Locked mockups:**
+- `docs/design/dossedart-handoff/PROPOSAL-cockpit-v5.html`
+- `docs/design/dossedart-handoff/PROPOSAL-player-overview-v4.html`
+
+**Working directory:** `.worktrees/dossedart-x01-cockpit` (branch `feat/dossedart-x01-cockpit`, branched from `main`).
+
+---
+
+## File map
+
+**New files:**
+```
+lib/widgets/dossedart/
+  dossedart_crt_frame.dart                 — reusable scanline + vignette + inset-bulge wrapper
+  dossedart_player_avatar.dart             — square avatar (photo or silhouette) with player-color border
+  x01/
+    dart_zone.dart                         — DartZone sum-type (single/double/triple per N + bull/dBull/miss)
+    dossedart_x01_topbar.dart              — ◀ EXIT · title · L 1/3 · RND 7
+    dossedart_x01_active_card.dart         — avatar, name, dart-dots, remaining, last turn, checkout-tip
+    dossedart_x01_dartboard.dart           — CustomPainter board + hit-test via polar coordinates
+    dossedart_x01_action_bar.dart          — ↶ UNDO · ✗ MISS · ⋯ MENU
+
+lib/screens/dossedart/x01/
+    dossedart_player_overview_screen.dart  — arcade scoreboard with all players
+
+test/widgets/dossedart/x01/
+    dossedart_x01_topbar_test.dart
+    dossedart_x01_active_card_test.dart
+    dossedart_x01_dartboard_test.dart
+    dossedart_x01_action_bar_test.dart
+
+integration_test/dossedart/
+    x01_cockpit_test.dart                  — smoke: cockpit renders + MENU → Player Overview navigation
+```
+
+**Modified files:**
+- `lib/screens/game_screen.dart` — adds `useDossedartDesign` constructor param + `_buildDossedartCockpit()` branch; existing build tree extracted unchanged into `_buildClassicScaffold()`. No logic edits.
+- `lib/screens/dossedart/dossedart_x01_setup_screen.dart` — passes `useDossedartDesign: true` to GameScreen.
+
+---
+
+## Task 1: Worktree setup
+
+**Files:** none (git operations)
+
+- [ ] **Step 1.1: Create the worktree**
+
+```bash
+git worktree add -b feat/dossedart-x01-cockpit .worktrees/dossedart-x01-cockpit main
+```
+Expected: `Preparing worktree (new branch 'feat/dossedart-x01-cockpit')`.
+
+- [ ] **Step 1.2: Switch to it for all later steps**
+
+```bash
+cd .worktrees/dossedart-x01-cockpit
+```
+
+- [ ] **Step 1.3: Baseline analyzer + widget tests**
+
+```bash
+flutter pub get
+flutter analyze
+flutter test test/
+```
+Expected: `No issues found!` and `All tests passed!`. If anything fails, stop and report (the branch should start clean since lint cleanup landed in PR #7).
+
+---
+
+## Task 2: DartZone model
+
+**Files:**
+- Create: `lib/widgets/dossedart/x01/dart_zone.dart`
+- Test: `test/widgets/dossedart/x01/dart_zone_test.dart`
+
+The dartboard taps need to produce one of these zones:
+- `single(int n)` for n in 1..20
+- `double(int n)` for n in 1..20
+- `triple(int n)` for n in 1..20
+- `bull` (outer bull = 25 single)
+- `dBull` (inner bull = 50, counts as a double for double-out)
+- `miss` (outside or non-tappable label band)
+
+The widget converts a zone to `(segment, multiplier)` for `_onDartHit(segment, multiplier)`.
+
+- [ ] **Step 2.1: Write the test**
+
+Create `test/widgets/dossedart/x01/dart_zone_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_scoring/widgets/dossedart/x01/dart_zone.dart';
+
+void main() {
+  group('DartZone.toSegmentMultiplier', () {
+    test('single 20 → (20, 1)', () {
+      expect(const DartZone.single(20).toSegmentMultiplier(), (20, 1));
+    });
+    test('double 16 → (16, 2)', () {
+      expect(const DartZone.double_(16).toSegmentMultiplier(), (16, 2));
+    });
+    test('triple 19 → (19, 3)', () {
+      expect(const DartZone.triple(19).toSegmentMultiplier(), (19, 3));
+    });
+    test('bull → (25, 1)', () {
+      expect(const DartZone.bull().toSegmentMultiplier(), (25, 1));
+    });
+    test('dBull → (25, 2)', () {
+      expect(const DartZone.dBull().toSegmentMultiplier(), (25, 2));
+    });
+    test('miss → (0, 1)', () {
+      expect(const DartZone.miss().toSegmentMultiplier(), (0, 1));
+    });
+  });
+}
+```
+
+- [ ] **Step 2.2: Run the test to verify it fails**
+
+```bash
+flutter test test/widgets/dossedart/x01/dart_zone_test.dart
+```
+Expected: FAIL — `Target of URI doesn't exist: 'package:dart_scoring/widgets/dossedart/x01/dart_zone.dart'`.
+
+- [ ] **Step 2.3: Implement DartZone**
+
+Create `lib/widgets/dossedart/x01/dart_zone.dart`:
+
+```dart
+/// A region on the DOSSEDART dartboard that a tap can resolve to.
+///
+/// Use [toSegmentMultiplier] to feed the result into the existing
+/// `_GameScreenState._onDartHit(int segment, int multiplier)` API.
+sealed class DartZone {
+  const DartZone();
+
+  const factory DartZone.single(int n) = _Single;
+  const factory DartZone.double_(int n) = _Double;
+  const factory DartZone.triple(int n) = _Triple;
+  const factory DartZone.bull() = _Bull;
+  const factory DartZone.dBull() = _DBull;
+  const factory DartZone.miss() = _Miss;
+
+  /// (segment, multiplier) pair for the production scoring engine.
+  /// MISS maps to (0, 1) so points = 0 * 1 = 0.
+  (int, int) toSegmentMultiplier();
+}
+
+class _Single extends DartZone {
+  const _Single(this.n);
+  final int n;
+  @override
+  (int, int) toSegmentMultiplier() => (n, 1);
+}
+
+class _Double extends DartZone {
+  const _Double(this.n);
+  final int n;
+  @override
+  (int, int) toSegmentMultiplier() => (n, 2);
+}
+
+class _Triple extends DartZone {
+  const _Triple(this.n);
+  final int n;
+  @override
+  (int, int) toSegmentMultiplier() => (n, 3);
+}
+
+class _Bull extends DartZone {
+  const _Bull();
+  @override
+  (int, int) toSegmentMultiplier() => (25, 1);
+}
+
+class _DBull extends DartZone {
+  const _DBull();
+  @override
+  (int, int) toSegmentMultiplier() => (25, 2);
+}
+
+class _Miss extends DartZone {
+  const _Miss();
+  @override
+  (int, int) toSegmentMultiplier() => (0, 1);
+}
+```
+
+- [ ] **Step 2.4: Run test, expect PASS**
+
+```bash
+flutter test test/widgets/dossedart/x01/dart_zone_test.dart
+flutter analyze lib/widgets/dossedart/x01/dart_zone.dart
+```
+Expected: PASS + `No issues found!`.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add lib/widgets/dossedart/x01/dart_zone.dart test/widgets/dossedart/x01/dart_zone_test.dart
+git commit -m "feat(dossedart): DartZone sum-type for dartboard hit-testing"
+```
+
+---
+
+## Task 3: DossedartCrtFrame widget
+
+**Files:**
+- Create: `lib/widgets/dossedart/dossedart_crt_frame.dart`
+
+Wraps any child with the shared DOSSEDART CRT effects: scanlines, vignette, inset shadows, optional decorative scan-beam (off by default in tests via the existing `ArcadeFrame.disableBeamForTest` flag).
+
+For this iteration we reuse the existing `ArcadeFrame` (already implements scanlines + vignette + beam). `DossedartCrtFrame` adds the inset-bulge box-shadows + border-radius styling — and is just a thin wrapper that puts a child inside an `ArcadeFrame` plus a `DecoratedBox` with the inset shadows.
+
+- [ ] **Step 3.1: Create the widget**
+
+Create `lib/widgets/dossedart/dossedart_crt_frame.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import '../../theme/dossedart_tokens.dart';
+import 'arcade_frame.dart';
+
+/// Wraps a screen body with the DOSSEDART CRT treatment:
+/// - ArcadeFrame (scanlines, vignette, scan-beam)
+/// - Inset shadows simulating CRT-glass corner-darkening
+/// - 16px border radius on the inner frame
+///
+/// The "physical bezel" shown in design mockups (grey plastic surround
+/// with power LED) is decorative-only in the mockup; in Flutter we
+/// convey the CRT feel via inset shadows alone.
+class DossedartCrtFrame extends StatelessWidget {
+  const DossedartCrtFrame({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: DossedartTokens.bg,
+      child: Stack(
+        children: [
+          Positioned.fill(child: ArcadeFrame(child: child)),
+          // Inset shadow overlay (CRT glass-bulge darkening)
+          const Positioned.fill(
+            child: IgnorePointer(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  boxShadow: [
+                    BoxShadow(
+                      color: Color(0xB3000000), // 70% black
+                      blurRadius: 60,
+                      spreadRadius: -30,
+                      offset: Offset.zero,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 3.2: Analyze**
+
+```bash
+flutter analyze lib/widgets/dossedart/dossedart_crt_frame.dart
+```
+Expected: No issues found.
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add lib/widgets/dossedart/dossedart_crt_frame.dart
+git commit -m "feat(dossedart): DossedartCrtFrame wrapper (ArcadeFrame + inset bulge)"
+```
+
+---
+
+## Task 4: DossedartPlayerAvatar widget
+
+**Files:**
+- Create: `lib/widgets/dossedart/dossedart_player_avatar.dart`
+- Test: `test/widgets/dossedart/dossedart_player_avatar_test.dart`
+
+Square avatar (NOT round). Shows the player's photo if `avatarPath` is non-null and the file exists; otherwise falls back to a `Icons.person` silhouette inside a surface-coloured square.
+
+- [ ] **Step 4.1: Write the widget test**
+
+Create `test/widgets/dossedart/dossedart_player_avatar_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_scoring/widgets/dossedart/dossedart_player_avatar.dart';
+
+void main() {
+  testWidgets('shows Icons.person silhouette when avatarPath is null',
+      (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: DossedartPlayerAvatar(
+          name: 'TEST',
+          avatarPath: null,
+          size: 56,
+          borderColor: Color(0xFFFF00AA),
+        ),
+      ),
+    ));
+    expect(find.byIcon(Icons.person), findsOneWidget);
+  });
+
+  testWidgets('shows Icons.person silhouette when avatarPath does not exist',
+      (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: DossedartPlayerAvatar(
+          name: 'TEST',
+          avatarPath: '/nonexistent/path/to/file.jpg',
+          size: 56,
+          borderColor: Color(0xFFFF00AA),
+        ),
+      ),
+    ));
+    expect(find.byIcon(Icons.person), findsOneWidget);
+  });
+}
+```
+
+- [ ] **Step 4.2: Run the test, verify it fails**
+
+```bash
+flutter test test/widgets/dossedart/dossedart_player_avatar_test.dart
+```
+Expected: FAIL — `Target of URI doesn't exist`.
+
+- [ ] **Step 4.3: Implement the widget**
+
+Create `lib/widgets/dossedart/dossedart_player_avatar.dart`:
+
+```dart
+import 'dart:io';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+
+/// Square avatar with a 2-3px player-color border. Shows the photo
+/// when available, falls back to an Icons.person silhouette.
+///
+/// Used by the DOSSEDART cockpit active card and Player Overview rows.
+/// Square shape and the per-player border colour are the DOSSEDART
+/// look — different from the round CircleAvatar that `PlayerAvatar` uses.
+class DossedartPlayerAvatar extends StatelessWidget {
+  const DossedartPlayerAvatar({
+    super.key,
+    required this.name,
+    required this.size,
+    required this.borderColor,
+    this.avatarPath,
+    this.borderWidth = 3,
+  });
+
+  final String name;
+  final double size;
+  final Color borderColor;
+  final String? avatarPath;
+  final double borderWidth;
+
+  bool _hasPhoto() {
+    if (avatarPath == null || avatarPath!.isEmpty || kIsWeb) return false;
+    return File(avatarPath!).existsSync();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: const Color(0xFF2A0050),
+        border: Border.all(color: borderColor, width: borderWidth),
+        boxShadow: [
+          BoxShadow(
+            color: borderColor.withValues(alpha: 0.5),
+            blurRadius: 8,
+          ),
+        ],
+      ),
+      child: _hasPhoto()
+          ? Image.file(File(avatarPath!), fit: BoxFit.cover)
+          : Center(
+              child: Icon(
+                Icons.person,
+                size: size * 0.6,
+                color: Colors.white,
+              ),
+            ),
+    );
+  }
+}
+```
+
+- [ ] **Step 4.4: Run test, expect PASS**
+
+```bash
+flutter test test/widgets/dossedart/dossedart_player_avatar_test.dart
+flutter analyze lib/widgets/dossedart/dossedart_player_avatar.dart
+```
+Expected: PASS + no analyzer issues.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add lib/widgets/dossedart/dossedart_player_avatar.dart test/widgets/dossedart/dossedart_player_avatar_test.dart
+git commit -m "feat(dossedart): DossedartPlayerAvatar (square, photo or silhouette)"
+```
+
+---
+
+## Task 5: DossedartX01TopBar widget
+
+**Files:**
+- Create: `lib/widgets/dossedart/x01/dossedart_x01_topbar.dart`
+- Test: `test/widgets/dossedart/x01/dossedart_x01_topbar_test.dart`
+
+Top bar: `◀ EXIT` (cyan, left), centered title (yellow, ellipsizes), `L {n}/{m} · RND {r}` (right, dim). 2px magenta bottom border, black background. Press Start 2P fonts.
+
+- [ ] **Step 5.1: Write the widget test**
+
+Create `test/widgets/dossedart/x01/dossedart_x01_topbar_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_scoring/widgets/dossedart/x01/dossedart_x01_topbar.dart';
+
+void main() {
+  testWidgets('renders exit + title + leg/round', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: DossedartX01TopBar(
+          title: 'X01 · 501 · D-OUT',
+          legIndex: 1,
+          legCount: 3,
+          roundNumber: 7,
+          onExit: () {},
+        ),
+      ),
+    ));
+    expect(find.text('◀ EXIT'), findsOneWidget);
+    expect(find.text('X01 · 501 · D-OUT'), findsOneWidget);
+    expect(find.text('L 1/3 · RND 7'), findsOneWidget);
+  });
+
+  testWidgets('onExit callback fires when EXIT tapped', (tester) async {
+    var exited = false;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: DossedartX01TopBar(
+          title: 'X01',
+          legIndex: 1,
+          legCount: 1,
+          roundNumber: 1,
+          onExit: () => exited = true,
+        ),
+      ),
+    ));
+    await tester.tap(find.text('◀ EXIT'));
+    expect(exited, isTrue);
+  });
+}
+```
+
+- [ ] **Step 5.2: Run the test to verify it fails**
+
+```bash
+flutter test test/widgets/dossedart/x01/dossedart_x01_topbar_test.dart
+```
+Expected: FAIL.
+
+- [ ] **Step 5.3: Implement the widget**
+
+Create `lib/widgets/dossedart/x01/dossedart_x01_topbar.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import '../../../theme/dossedart_tokens.dart';
+
+/// DOSSEDART X01 cockpit top bar: ◀ EXIT · title · L n/m · RND r.
+class DossedartX01TopBar extends StatelessWidget {
+  const DossedartX01TopBar({
+    super.key,
+    required this.title,
+    required this.legIndex,
+    required this.legCount,
+    required this.roundNumber,
+    required this.onExit,
+  });
+
+  final String title;
+  final int legIndex;
+  final int legCount;
+  final int roundNumber;
+  final VoidCallback onExit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: const BoxDecoration(
+        color: Colors.black,
+        border: Border(
+          bottom: BorderSide(color: DossedartTokens.magenta, width: 2),
+        ),
+      ),
+      child: Row(
+        children: [
+          GestureDetector(
+            onTap: onExit,
+            child: const Text(
+              '◀ EXIT',
+              style: TextStyle(
+                fontFamily: 'VT323',
+                fontSize: 18,
+                color: DossedartTokens.cyan,
+                letterSpacing: 2,
+                height: 1,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Center(
+              child: Text(
+                title,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  fontFamily: 'PressStart2P',
+                  fontSize: 11,
+                  color: DossedartTokens.yellow,
+                  letterSpacing: 2,
+                  height: 1.3,
+                ),
+              ),
+            ),
+          ),
+          Text(
+            'L $legIndex/$legCount · RND $roundNumber',
+            style: const TextStyle(
+              fontFamily: 'VT323',
+              fontSize: 14,
+              color: Colors.white54,
+              letterSpacing: 2,
+              height: 1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 5.4: Run test, expect PASS**
+
+```bash
+flutter test test/widgets/dossedart/x01/dossedart_x01_topbar_test.dart
+flutter analyze lib/widgets/dossedart/x01/dossedart_x01_topbar.dart
+```
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add lib/widgets/dossedart/x01/dossedart_x01_topbar.dart test/widgets/dossedart/x01/dossedart_x01_topbar_test.dart
+git commit -m "feat(dossedart): DossedartX01TopBar (exit/title/leg+round)"
+```
+
+---
+
+## Task 6: DossedartX01ActiveCard widget
+
+**Files:**
+- Create: `lib/widgets/dossedart/x01/dossedart_x01_active_card.dart`
+- Test: `test/widgets/dossedart/x01/dossedart_x01_active_card_test.dart`
+
+Active player card. Avatar + name (auto-shrinks), dart-dots (3 squares: filled = dart thrown, hollow = not), REMAINING number (big), LAST 3 throws row, optional checkout-tip strip.
+
+- [ ] **Step 6.1: Add a name-tier helper to dart_zone.dart**
+
+Actually a separate place is cleaner. Add it inside the active card file itself as a private function:
+
+(see Step 6.3 — `_nameTier()` is part of the widget file)
+
+- [ ] **Step 6.2: Write the widget test**
+
+Create `test/widgets/dossedart/x01/dossedart_x01_active_card_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_scoring/widgets/dossedart/x01/dossedart_x01_active_card.dart';
+
+void main() {
+  Widget harness({
+    String name = 'MIA',
+    int remaining = 170,
+    int currentDartIndex = 2,
+    String? lastTurn = 'T20 · S20 · S20',
+    int? lastTurnSum = 80,
+    String? checkoutTip,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: DossedartX01ActiveCard(
+          playerName: name,
+          avatarPath: null,
+          accentColor: const Color(0xFFFF00AA),
+          remaining: remaining,
+          currentDartIndex: currentDartIndex,
+          lastTurnLabel: lastTurn,
+          lastTurnSum: lastTurnSum,
+          checkoutTip: checkoutTip,
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders name, remaining, last turn', (tester) async {
+    await tester.pumpWidget(harness());
+    expect(find.text('MIA'), findsOneWidget);
+    expect(find.text('170'), findsOneWidget);
+    expect(find.text('T20 · S20 · S20'), findsOneWidget);
+    expect(find.text('= 80'), findsOneWidget);
+  });
+
+  testWidgets('hides checkout-tip when null', (tester) async {
+    await tester.pumpWidget(harness());
+    expect(find.textContaining('▶'), findsNothing);
+  });
+
+  testWidgets('shows checkout-tip when provided', (tester) async {
+    await tester.pumpWidget(harness(checkoutTip: 'T20 › S16 › D-BULL'));
+    expect(find.text('▶ T20 › S16 › D-BULL'), findsOneWidget);
+  });
+
+  testWidgets('long name does not overflow (no exception)',
+      (tester) async {
+    await tester.pumpWidget(harness(name: 'CHRISTOPHER ALEXANDER VON LONGNAME'));
+    expect(tester.takeException(), isNull);
+  });
+}
+```
+
+- [ ] **Step 6.3: Implement the widget**
+
+Create `lib/widgets/dossedart/x01/dossedart_x01_active_card.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import '../../../theme/dossedart_tokens.dart';
+import '../dossedart_player_avatar.dart';
+
+/// Active player card shown in the DOSSEDART X01 cockpit.
+class DossedartX01ActiveCard extends StatelessWidget {
+  const DossedartX01ActiveCard({
+    super.key,
+    required this.playerName,
+    required this.avatarPath,
+    required this.accentColor,
+    required this.remaining,
+    required this.currentDartIndex,
+    required this.lastTurnLabel,
+    required this.lastTurnSum,
+    required this.checkoutTip,
+  });
+
+  final String playerName;
+  final String? avatarPath;
+  final Color accentColor;
+  final int remaining;
+  final int currentDartIndex; // 0..3
+  final String? lastTurnLabel; // e.g., 'T20 · S20 · S20' (null = no previous turn)
+  final int? lastTurnSum;
+  final String? checkoutTip;
+
+  double _nameFontSize() {
+    final len = playerName.length;
+    if (len <= 6) return 18;
+    if (len <= 10) return 15;
+    if (len <= 16) return 12;
+    return 10;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final nameSize = _nameFontSize();
+    return Container(
+      margin: const EdgeInsets.fromLTRB(14, 12, 14, 10),
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+      decoration: BoxDecoration(
+        border: Border.all(color: accentColor, width: 3),
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            accentColor.withValues(alpha: 0.10),
+            accentColor.withValues(alpha: 0.02),
+          ],
+        ),
+        boxShadow: [
+          BoxShadow(color: accentColor.withValues(alpha: 0.25), blurRadius: 14),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Row 1: avatar + name + dart-dots
+          Row(
+            children: [
+              DossedartPlayerAvatar(
+                name: playerName,
+                avatarPath: avatarPath,
+                size: 56,
+                borderColor: accentColor,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      playerName,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontFamily: 'PressStart2P',
+                        fontSize: nameSize,
+                        color: Colors.white,
+                        letterSpacing: nameSize >= 15 ? 2 : 1.5,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Row(
+                      children: [
+                        for (int i = 0; i < 3; i++) ...[
+                          Container(
+                            width: 9,
+                            height: 9,
+                            decoration: BoxDecoration(
+                              color: i < currentDartIndex ? accentColor : Colors.transparent,
+                              border: Border.all(color: accentColor, width: 2),
+                            ),
+                          ),
+                          const SizedBox(width: 6),
+                        ],
+                        Text(
+                          'DART $currentDartIndex/3',
+                          style: const TextStyle(
+                            fontFamily: 'VT323',
+                            fontSize: 13,
+                            color: Colors.white54,
+                            letterSpacing: 1,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          // Row 2: REMAINING label + big number
+          const SizedBox(height: 12),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              const Text(
+                'REMAINING',
+                style: TextStyle(
+                  fontFamily: 'PressStart2P',
+                  fontSize: 9,
+                  color: Colors.white70,
+                  letterSpacing: 1.5,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                '$remaining',
+                style: TextStyle(
+                  fontFamily: 'PressStart2P',
+                  fontSize: 60,
+                  color: accentColor,
+                  letterSpacing: 2,
+                  height: 1,
+                  shadows: [
+                    Shadow(color: accentColor.withValues(alpha: 0.7), blurRadius: 16),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          // Row 3: last turn (above dashed separator)
+          if (lastTurnLabel != null) ...[
+            const SizedBox(height: 10),
+            Container(
+              padding: const EdgeInsets.only(top: 8),
+              decoration: BoxDecoration(
+                border: Border(
+                  top: BorderSide(
+                    color: accentColor.withValues(alpha: 0.4),
+                    width: 1,
+                    style: BorderStyle.solid, // Flutter has no dashed; rendered as solid thin
+                  ),
+                ),
+              ),
+              child: Row(
+                children: [
+                  const Text(
+                    'LAST',
+                    style: TextStyle(
+                      fontFamily: 'PressStart2P',
+                      fontSize: 9,
+                      color: Colors.white70,
+                      letterSpacing: 1.5,
+                    ),
+                  ),
+                  Expanded(
+                    child: Text(
+                      lastTurnLabel!,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        fontFamily: 'VT323',
+                        fontSize: 20,
+                        color: DossedartTokens.yellow,
+                        letterSpacing: 1.5,
+                      ),
+                    ),
+                  ),
+                  if (lastTurnSum != null)
+                    Text(
+                      '= $lastTurnSum',
+                      style: const TextStyle(
+                        fontFamily: 'PressStart2P',
+                        fontSize: 13,
+                        color: DossedartTokens.yellow,
+                        letterSpacing: 1,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+          // Row 4: checkout tip
+          if (checkoutTip != null) ...[
+            const SizedBox(height: 10),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              decoration: BoxDecoration(
+                color: DossedartTokens.green.withValues(alpha: 0.06),
+                border: Border.all(color: DossedartTokens.green, width: 2),
+                boxShadow: [
+                  BoxShadow(
+                    color: DossedartTokens.green.withValues(alpha: 0.4),
+                    blurRadius: 14,
+                  ),
+                ],
+              ),
+              child: Text(
+                '▶ $checkoutTip',
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontFamily: 'PressStart2P',
+                  fontSize: 10,
+                  color: DossedartTokens.green,
+                  letterSpacing: 1,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 6.4: Run tests + analyzer**
+
+```bash
+flutter test test/widgets/dossedart/x01/dossedart_x01_active_card_test.dart
+flutter analyze lib/widgets/dossedart/x01/dossedart_x01_active_card.dart
+```
+Expected: PASS, no issues.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add lib/widgets/dossedart/x01/dossedart_x01_active_card.dart test/widgets/dossedart/x01/dossedart_x01_active_card_test.dart
+git commit -m "feat(dossedart): DossedartX01ActiveCard (avatar/name/dots/remaining/last/checkout)"
+```
+
+---
+
+## Task 7: DossedartX01ActionBar widget
+
+**Files:**
+- Create: `lib/widgets/dossedart/x01/dossedart_x01_action_bar.dart`
+- Test: `test/widgets/dossedart/x01/dossedart_x01_action_bar_test.dart`
+
+Three buttons: UNDO (magenta border, flex 1), MISS (filled orange, flex 2 primary), MENU (cyan border, flex 1).
+
+- [ ] **Step 7.1: Write the widget test**
+
+Create `test/widgets/dossedart/x01/dossedart_x01_action_bar_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_scoring/widgets/dossedart/x01/dossedart_x01_action_bar.dart';
+
+void main() {
+  testWidgets('renders all three labels', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: DossedartX01ActionBar(
+          onUndo: () {},
+          onMiss: () {},
+          onMenu: () {},
+        ),
+      ),
+    ));
+    expect(find.text('↶ UNDO'), findsOneWidget);
+    expect(find.text('✗ MISS'), findsOneWidget);
+    expect(find.text('⋯ MENU'), findsOneWidget);
+  });
+
+  testWidgets('callbacks fire on tap', (tester) async {
+    var u = false, m = false, x = false;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: DossedartX01ActionBar(
+          onUndo: () => u = true,
+          onMiss: () => m = true,
+          onMenu: () => x = true,
+        ),
+      ),
+    ));
+    await tester.tap(find.text('↶ UNDO'));
+    await tester.tap(find.text('✗ MISS'));
+    await tester.tap(find.text('⋯ MENU'));
+    expect(u, isTrue);
+    expect(m, isTrue);
+    expect(x, isTrue);
+  });
+}
+```
+
+- [ ] **Step 7.2: Run test to verify it fails**
+
+```bash
+flutter test test/widgets/dossedart/x01/dossedart_x01_action_bar_test.dart
+```
+Expected: FAIL.
+
+- [ ] **Step 7.3: Implement the widget**
+
+Create `lib/widgets/dossedart/x01/dossedart_x01_action_bar.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import '../../../theme/dossedart_tokens.dart';
+
+class DossedartX01ActionBar extends StatelessWidget {
+  const DossedartX01ActionBar({
+    super.key,
+    required this.onUndo,
+    required this.onMiss,
+    required this.onMenu,
+  });
+
+  final VoidCallback onUndo;
+  final VoidCallback onMiss;
+  final VoidCallback onMenu;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+      decoration: const BoxDecoration(
+        color: Colors.black,
+        border: Border(
+          top: BorderSide(color: DossedartTokens.yellow, width: 2),
+        ),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            flex: 1,
+            child: _Btn(
+              label: '↶ UNDO',
+              borderColor: DossedartTokens.magenta,
+              fg: Colors.white,
+              onTap: onUndo,
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            flex: 2,
+            child: _Btn(
+              label: '✗ MISS',
+              borderColor: Colors.white,
+              bg: DossedartTokens.orange,
+              fg: Colors.black,
+              onTap: onMiss,
+              glow: true,
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            flex: 1,
+            child: _Btn(
+              label: '⋯ MENU',
+              borderColor: DossedartTokens.cyan,
+              fg: DossedartTokens.cyan,
+              onTap: onMenu,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Btn extends StatelessWidget {
+  const _Btn({
+    required this.label,
+    required this.borderColor,
+    required this.fg,
+    required this.onTap,
+    this.bg,
+    this.glow = false,
+  });
+
+  final String label;
+  final Color borderColor;
+  final Color fg;
+  final VoidCallback onTap;
+  final Color? bg;
+  final bool glow;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        decoration: BoxDecoration(
+          color: bg,
+          border: Border.all(color: borderColor, width: 2),
+          boxShadow: glow
+              ? [BoxShadow(color: DossedartTokens.orange.withValues(alpha: 0.55), blurRadius: 16)]
+              : null,
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          label,
+          style: TextStyle(
+            fontFamily: 'PressStart2P',
+            fontSize: 11,
+            color: fg,
+            letterSpacing: 1.5,
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 7.4: Run tests + analyzer**
+
+```bash
+flutter test test/widgets/dossedart/x01/dossedart_x01_action_bar_test.dart
+flutter analyze lib/widgets/dossedart/x01/dossedart_x01_action_bar.dart
+```
+Expected: PASS.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add lib/widgets/dossedart/x01/dossedart_x01_action_bar.dart test/widgets/dossedart/x01/dossedart_x01_action_bar_test.dart
+git commit -m "feat(dossedart): DossedartX01ActionBar (undo/miss/menu)"
+```
+
+---
+
+## Task 8: DossedartX01Dartboard — geometry + render + hit-test
+
+**Files:**
+- Create: `lib/widgets/dossedart/x01/dossedart_x01_dartboard.dart`
+- Test: `test/widgets/dossedart/x01/dossedart_x01_dartboard_test.dart`
+
+The big one. CustomPainter draws the segments. `GestureDetector` with `onTapUp` converts the local position to polar coordinates and picks the zone.
+
+**Geometry constants (radii as fractions of board radius):**
+
+| Threshold | Value |
+|---|---|
+| `kDBullR` | 0.05 |
+| `kBullR` | 0.12 |
+| `kInnerSingleR` | 0.47 |
+| `kTripleR` | 0.58 |
+| `kOuterSingleR` | 0.82 |
+| `kDoubleR` | 0.95 |
+| `kEdgeR` | 1.00 |
+
+**Segment ordering (starting at 20, top; clockwise):**
+`[20, 1, 18, 4, 13, 6, 10, 15, 2, 17, 3, 19, 7, 16, 8, 11, 14, 9, 12, 5]`
+
+- [ ] **Step 8.1: Write the hit-test tests first**
+
+Create `test/widgets/dossedart/x01/dossedart_x01_dartboard_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_scoring/widgets/dossedart/x01/dart_zone.dart';
+import 'package:dart_scoring/widgets/dossedart/x01/dossedart_x01_dartboard.dart';
+
+void main() {
+  group('hit-test', () {
+    // Board has radius 100 in unit space; centre at (0,0).
+    // Angles: 0° = top (12 o'clock), clockwise positive.
+
+    test('centre tap → dBull', () {
+      expect(zoneForPolar(0, 0), const DartZone.dBull());
+    });
+
+    test('inside bull ring (r=0.10) → bull', () {
+      expect(zoneForPolar(0.10, 0), const DartZone.bull());
+    });
+
+    test('inner single at top (r=0.30, angle 0) → single 20', () {
+      expect(zoneForPolar(0.30, 0), const DartZone.single(20));
+    });
+
+    test('triple ring at top (r=0.52, angle 0) → triple 20', () {
+      expect(zoneForPolar(0.52, 0), const DartZone.triple(20));
+    });
+
+    test('outer single at top (r=0.70, angle 0) → single 20', () {
+      expect(zoneForPolar(0.70, 0), const DartZone.single(20));
+    });
+
+    test('double ring at top (r=0.90, angle 0) → double 20', () {
+      expect(zoneForPolar(0.90, 0), const DartZone.double_(20));
+    });
+
+    test('label band (r=0.98) → miss', () {
+      expect(zoneForPolar(0.98, 0), const DartZone.miss());
+    });
+
+    test('outside the board (r=1.1) → miss', () {
+      expect(zoneForPolar(1.1, 0), const DartZone.miss());
+    });
+
+    test('right side (angle 90°) → segment 6', () {
+      // Per standard ordering, segment 90° clockwise from top is 6.
+      expect(zoneForPolar(0.30, 90), const DartZone.single(6));
+    });
+
+    test('bottom (angle 180°) → segment 3', () {
+      expect(zoneForPolar(0.30, 180), const DartZone.single(3));
+    });
+  });
+
+  testWidgets('GestureDetector fires onTap with computed zone',
+      (tester) async {
+    DartZone? lastZone;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: 320,
+            height: 320,
+            child: DossedartX01Dartboard(
+              onTap: (z) => lastZone = z,
+            ),
+          ),
+        ),
+      ),
+    ));
+    // Tap dead-centre: dBull.
+    await tester.tapAt(tester.getCenter(find.byType(DossedartX01Dartboard)));
+    expect(lastZone, const DartZone.dBull());
+  });
+}
+```
+
+- [ ] **Step 8.2: Run tests to verify they fail**
+
+```bash
+flutter test test/widgets/dossedart/x01/dossedart_x01_dartboard_test.dart
+```
+Expected: FAIL — `zoneForPolar` undefined and `DossedartX01Dartboard` doesn't exist.
+
+- [ ] **Step 8.3: Implement the widget + hit-test**
+
+Create `lib/widgets/dossedart/x01/dossedart_x01_dartboard.dart`:
+
+```dart
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+import '../../../theme/dossedart_tokens.dart';
+import 'dart_zone.dart';
+
+/// Standard dart segment order starting at 20 (top), going clockwise.
+const List<int> kSegmentOrder = [
+  20, 1, 18, 4, 13, 6, 10, 15, 2, 17, 3, 19, 7, 16, 8, 11, 14, 9, 12, 5,
+];
+
+// Radius thresholds as fractions of board radius.
+// Visual = hit-test (no surprise misses).
+const double kDBullR = 0.05;
+const double kBullR = 0.12;
+const double kInnerSingleR = 0.47;
+const double kTripleR = 0.58;
+const double kOuterSingleR = 0.82;
+const double kDoubleR = 0.95;
+
+/// Resolve a tap at polar (r, angleDeg) — r as a fraction of board
+/// radius, angleDeg measured clockwise from 12 o'clock — to a DartZone.
+DartZone zoneForPolar(double r, double angleDeg) {
+  if (r <= kDBullR) return const DartZone.dBull();
+  if (r <= kBullR) return const DartZone.bull();
+  if (r > kDoubleR) return const DartZone.miss();
+
+  // Normalise angle to [0, 360).
+  double a = angleDeg % 360;
+  if (a < 0) a += 360;
+  // Each segment is 18°, centred on its number. Segment 0 (the "20"
+  // segment) spans [-9°, 9°). So shift by +9° to make segment 0 start at 0°.
+  final segIdx = ((a + 9) % 360 / 18).floor();
+  final n = kSegmentOrder[segIdx];
+
+  if (r <= kInnerSingleR) return DartZone.single(n);
+  if (r <= kTripleR) return DartZone.triple(n);
+  if (r <= kOuterSingleR) return DartZone.single(n);
+  return DartZone.double_(n);
+}
+
+/// Renders the DOSSEDART arcade dartboard and reports taps as DartZones.
+/// The widget fills its available space; wrap in an AspectRatio(1) to
+/// keep it square.
+class DossedartX01Dartboard extends StatelessWidget {
+  const DossedartX01Dartboard({super.key, required this.onTap});
+
+  final ValueChanged<DartZone> onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (ctx, constraints) {
+        final size = math.min(constraints.maxWidth, constraints.maxHeight);
+        return GestureDetector(
+          onTapUp: (details) {
+            final centre = Offset(size / 2, size / 2);
+            final offset = details.localPosition - centre;
+            final boardRadius = size / 2;
+            final r = offset.distance / boardRadius;
+            final angleRad = math.atan2(offset.dx, -offset.dy); // 12 o'clock = 0, CW positive
+            final angleDeg = angleRad * 180 / math.pi;
+            onTap(zoneForPolar(r, angleDeg));
+          },
+          child: SizedBox(
+            width: size,
+            height: size,
+            child: CustomPaint(painter: _DartboardPainter()),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _DartboardPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final r = size.width / 2;
+    final c = Offset(r, r);
+
+    // Outer frame (magenta border + glow already comes from surrounding
+    // BoxDecoration on the parent; here we just fill background).
+    final bg = Paint()..color = DossedartTokens.surface;
+    canvas.drawCircle(c, r, bg);
+
+    const slice = math.pi * 2 / 20;
+    for (int i = 0; i < 20; i++) {
+      final start = -slice / 2 + i * slice - math.pi / 2;
+      final end = start + slice;
+      final segCol = (i % 2 == 0)
+          ? DossedartTokens.magenta.withValues(alpha: 0.35)
+          : DossedartTokens.cyan.withValues(alpha: 0.35);
+
+      _wedge(canvas, c, r * kBullR, r * kInnerSingleR, start, end, segCol);
+      _wedge(canvas, c, r * kInnerSingleR, r * kTripleR, start, end, DossedartTokens.green);
+      _wedge(canvas, c, r * kTripleR, r * kOuterSingleR, start, end, segCol);
+      _wedge(canvas, c, r * kOuterSingleR, r * kDoubleR, start, end, DossedartTokens.yellow);
+      _wedge(canvas, c, r * kDoubleR, r, start, end, DossedartTokens.bg);
+
+      // Segment number label, placed in the outer band.
+      final midAng = (start + end) / 2;
+      final lx = c.dx + math.cos(midAng) * r * 0.975;
+      final ly = c.dy + math.sin(midAng) * r * 0.975;
+      final n = kSegmentOrder[i];
+      final tp = TextPainter(
+        text: TextSpan(
+          text: '$n',
+          style: const TextStyle(
+            fontFamily: 'PressStart2P',
+            fontSize: 11,
+            color: Colors.white,
+          ),
+        ),
+        textDirection: TextDirection.ltr,
+      )..layout();
+      tp.paint(canvas, Offset(lx - tp.width / 2, ly - tp.height / 2));
+    }
+
+    // Bull / D-Bull
+    canvas.drawCircle(c, r * kBullR, Paint()..color = DossedartTokens.orange);
+    canvas.drawCircle(c, r * kDBullR, Paint()..color = DossedartTokens.red);
+
+    // White stroke around bulls
+    final stroke = Paint()
+      ..color = Colors.white
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2;
+    canvas.drawCircle(c, r * kBullR, stroke);
+    canvas.drawCircle(c, r * kDBullR, stroke);
+
+    // Magenta border ring
+    final border = Paint()
+      ..color = DossedartTokens.magenta
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 3;
+    canvas.drawCircle(c, r - 1.5, border);
+  }
+
+  void _wedge(Canvas canvas, Offset c, double rInner, double rOuter,
+      double startAng, double endAng, Color fill) {
+    final path = Path()
+      ..moveTo(c.dx + math.cos(startAng) * rInner, c.dy + math.sin(startAng) * rInner)
+      ..lineTo(c.dx + math.cos(startAng) * rOuter, c.dy + math.sin(startAng) * rOuter)
+      ..arcTo(
+        Rect.fromCircle(center: c, radius: rOuter),
+        startAng, endAng - startAng, false,
+      )
+      ..lineTo(c.dx + math.cos(endAng) * rInner, c.dy + math.sin(endAng) * rInner)
+      ..arcTo(
+        Rect.fromCircle(center: c, radius: rInner),
+        endAng, -(endAng - startAng), false,
+      )
+      ..close();
+    canvas.drawPath(path, Paint()..color = fill);
+  }
+
+  @override
+  bool shouldRepaint(_DartboardPainter oldDelegate) => false;
+}
+```
+
+- [ ] **Step 8.4: Run tests + analyzer**
+
+```bash
+flutter test test/widgets/dossedart/x01/dossedart_x01_dartboard_test.dart
+flutter analyze lib/widgets/dossedart/x01/dossedart_x01_dartboard.dart
+```
+Expected: ALL PASS. If a specific angle-segment test fails, the segment-index calculation in `zoneForPolar` may need a +/- 1 adjustment — the "20 segment spans -9°..+9°" interpretation is correct; verify against the test for "right side (90°) → 6".
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add lib/widgets/dossedart/x01/dossedart_x01_dartboard.dart test/widgets/dossedart/x01/dossedart_x01_dartboard_test.dart
+git commit -m "feat(dossedart): DossedartX01Dartboard (geometry + hit-test)"
+```
+
+---
+
+## Task 9: DossedartPlayerOverviewScreen
+
+**Files:**
+- Create: `lib/screens/dossedart/x01/dossedart_player_overview_screen.dart`
+
+The arcade scoreboard screen pushed from the cockpit's MENU. Inputs: list of player view-models (already includes name, avatarPath, remaining, last turn label, last turn sum, avg, hit%, miss%). The screen does NOT compute stats — that's the cockpit's job; the screen just renders.
+
+- [ ] **Step 9.1: Create the screen**
+
+Create `lib/screens/dossedart/x01/dossedart_player_overview_screen.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import '../../../theme/dossedart_tokens.dart';
+import '../../../widgets/dossedart/dossedart_crt_frame.dart';
+import '../../../widgets/dossedart/dossedart_player_avatar.dart';
+
+/// View-model for one player row in the overview.
+class PlayerOverviewRow {
+  const PlayerOverviewRow({
+    required this.name,
+    required this.avatarPath,
+    required this.remaining,
+    required this.lastTurnLabel,
+    required this.lastTurnSum,
+    required this.avg,
+    required this.hitPct,
+    required this.missPct,
+  });
+
+  final String name;
+  final String? avatarPath;
+  final int remaining;
+  final String lastTurnLabel; // e.g., 'T20 · S20 · S20' or '— · — · —'
+  final int lastTurnSum;
+  final double avg;
+  final int hitPct;
+  final int missPct;
+}
+
+class DossedartPlayerOverviewScreen extends StatelessWidget {
+  const DossedartPlayerOverviewScreen({
+    super.key,
+    required this.title,
+    required this.roundNumber,
+    required this.rows,
+  });
+
+  final String title; // e.g., 'CAST · X01 501'
+  final int roundNumber;
+  final List<PlayerOverviewRow> rows;
+
+  static double _nameFontSize(int len) {
+    if (len <= 6) return 14;
+    if (len <= 10) return 12;
+    return 10;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: DossedartTokens.bg,
+      body: DossedartCrtFrame(
+        child: SafeArea(
+          child: Column(
+            children: [
+              _TopBar(title: title, roundNumber: roundNumber),
+              const _Marquee(text: '► SCOREBOARD ◄'),
+              const _ColHeader(),
+              Expanded(
+                child: ListView.builder(
+                  padding: const EdgeInsets.fromLTRB(14, 6, 14, 14),
+                  itemCount: rows.length,
+                  itemBuilder: (ctx, i) => _Row(rank: i + 1, data: rows[i]),
+                ),
+              ),
+              const _FooterMarquee(text: '★ ★ ★ INSERT DART TO CONTINUE ★ ★ ★'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TopBar extends StatelessWidget {
+  const _TopBar({required this.title, required this.roundNumber});
+  final String title;
+  final int roundNumber;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: const BoxDecoration(
+        color: Colors.black,
+        border: Border(bottom: BorderSide(color: DossedartTokens.magenta, width: 2)),
+      ),
+      child: Row(
+        children: [
+          GestureDetector(
+            onTap: () => Navigator.of(context).pop(),
+            child: const Text(
+              '◀ BACK',
+              style: TextStyle(
+                fontFamily: 'VT323', fontSize: 18, color: DossedartTokens.cyan,
+                letterSpacing: 2, height: 1,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Center(
+              child: Text(
+                title,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  fontFamily: 'PressStart2P', fontSize: 11, color: DossedartTokens.yellow,
+                  letterSpacing: 2,
+                ),
+              ),
+            ),
+          ),
+          Text(
+            'RND $roundNumber',
+            style: const TextStyle(
+              fontFamily: 'VT323', fontSize: 14, color: Colors.white54, letterSpacing: 2,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Marquee extends StatelessWidget {
+  const _Marquee({required this.text});
+  final String text;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.4),
+        border: const Border(bottom: BorderSide(color: Color(0x66FF00AA), width: 1)),
+      ),
+      child: Text(
+        text,
+        textAlign: TextAlign.center,
+        style: const TextStyle(
+          fontFamily: 'PressStart2P',
+          fontSize: 12,
+          color: DossedartTokens.magenta,
+          letterSpacing: 4,
+        ),
+      ),
+    );
+  }
+}
+
+class _ColHeader extends StatelessWidget {
+  const _ColHeader();
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(18, 8, 18, 6),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: Color(0x4D00E5FF), width: 1)),
+      ),
+      child: const Row(
+        children: [
+          SizedBox(width: 32, child: Text('#', style: _hStyle)),
+          SizedBox(width: 54),
+          Expanded(child: Text('PLAYER', style: _hStyle)),
+          Text('REMAIN', style: _hStyle),
+        ],
+      ),
+    );
+  }
+
+  static const _hStyle = TextStyle(
+    fontFamily: 'PressStart2P', fontSize: 8, color: DossedartTokens.cyan,
+    letterSpacing: 1.5,
+  );
+}
+
+class _Row extends StatelessWidget {
+  const _Row({required this.rank, required this.data});
+  final int rank;
+  final PlayerOverviewRow data;
+
+  @override
+  Widget build(BuildContext context) {
+    final nameSize = DossedartPlayerOverviewScreen._nameFontSize(data.name.length);
+    return Container(
+      padding: const EdgeInsets.fromLTRB(4, 10, 4, 12),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: Color(0x2EFFFFFF), width: 1)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Line 1: rank | avatar | name | remaining
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              SizedBox(
+                width: 32,
+                child: Text(
+                  rank.toString().padLeft(2, '0'),
+                  style: const TextStyle(
+                    fontFamily: 'PressStart2P', fontSize: 16,
+                    color: DossedartTokens.yellow, letterSpacing: 1,
+                  ),
+                ),
+              ),
+              DossedartPlayerAvatar(
+                name: data.name,
+                avatarPath: data.avatarPath,
+                size: 44,
+                borderColor: DossedartTokens.magenta,
+                borderWidth: 2,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  data.name,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontFamily: 'PressStart2P', fontSize: nameSize, color: Colors.white,
+                    letterSpacing: nameSize >= 13 ? 2 : 1.2,
+                  ),
+                ),
+              ),
+              Text(
+                '${data.remaining}',
+                style: const TextStyle(
+                  fontFamily: 'PressStart2P', fontSize: 26,
+                  color: DossedartTokens.magenta, letterSpacing: 1, height: 1,
+                ),
+              ),
+            ],
+          ),
+          // Line 2: AVG · HIT%
+          Padding(
+            padding: const EdgeInsets.only(left: 88, top: 8),
+            child: Text(
+              'AVG ${data.avg.toStringAsFixed(1)} · HIT ${data.hitPct}%',
+              style: const TextStyle(
+                fontFamily: 'VT323', fontSize: 16, color: Colors.white60, letterSpacing: 1.5,
+              ),
+            ),
+          ),
+          // Line 3: LAST throws (full width)
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            decoration: BoxDecoration(
+              color: DossedartTokens.yellow.withValues(alpha: 0.08),
+              border: Border.all(color: DossedartTokens.yellow.withValues(alpha: 0.35), width: 1),
+            ),
+            child: Row(
+              children: [
+                const Text(
+                  'LAST',
+                  style: TextStyle(
+                    fontFamily: 'PressStart2P', fontSize: 8,
+                    color: Color(0xA6FFD200), letterSpacing: 1,
+                  ),
+                ),
+                Expanded(
+                  child: Text(
+                    data.lastTurnLabel,
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      fontFamily: 'VT323', fontSize: 22, letterSpacing: 2,
+                      color: DossedartTokens.yellow,
+                    ),
+                  ),
+                ),
+                Text(
+                  '${data.lastTurnSum}',
+                  style: const TextStyle(
+                    fontFamily: 'PressStart2P', fontSize: 12,
+                    color: DossedartTokens.yellow,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FooterMarquee extends StatelessWidget {
+  const _FooterMarquee({required this.text});
+  final String text;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      decoration: const BoxDecoration(
+        color: Colors.black,
+        border: Border(top: BorderSide(color: Color(0x6600E5FF), width: 1)),
+      ),
+      child: Text(
+        text,
+        textAlign: TextAlign.center,
+        style: const TextStyle(
+          fontFamily: 'PressStart2P', fontSize: 9, color: DossedartTokens.cyan,
+          letterSpacing: 3,
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 9.2: Analyze**
+
+```bash
+flutter analyze lib/screens/dossedart/x01/dossedart_player_overview_screen.dart
+```
+Expected: No issues.
+
+- [ ] **Step 9.3: Commit**
+
+```bash
+git add lib/screens/dossedart/x01/dossedart_player_overview_screen.dart
+git commit -m "feat(dossedart): DossedartPlayerOverviewScreen (arcade scoreboard)"
+```
+
+---
+
+## Task 10: Add useDossedartDesign flag to GameScreen + extract classic build
+
+**Files:**
+- Modify: `lib/screens/game_screen.dart`
+
+This task only refactors — no new behaviour. The existing `build()` body becomes `_buildClassicScaffold(context)`. A new `_buildDossedartCockpit(context)` stub returns the same classic scaffold for now (it gets replaced in Task 11). The new constructor param defaults to `false` so nothing changes for existing callers yet.
+
+- [ ] **Step 10.1: Add constructor field**
+
+Modify `lib/screens/game_screen.dart` line 28-46:
+
+```dart
+class GameScreen extends StatefulWidget {
+  final List<Player> players;
+  final String masterOut;
+  final int startingScore;
+  final bool handicap;
+  final bool noBust;
+  final bool useDossedartDesign;
+
+  const GameScreen({
+    super.key,
+    required this.players,
+    this.masterOut = 'none',
+    required this.startingScore,
+    this.handicap = false,
+    this.noBust = false,
+    this.useDossedartDesign = false,
+  });
+
+  @override
+  State<GameScreen> createState() => _GameScreenState();
+}
+```
+
+- [ ] **Step 10.2: Refactor build() into branch**
+
+Find the existing `Widget build(BuildContext context) { ... }` in `_GameScreenState` (around line 1417). Rename the existing method body's wrapper to a private method, and add a top-level `build` that picks.
+
+The existing build method is large — copy its full body verbatim, then rename. Do not modify the body.
+
+The simplest mechanical change:
+
+```dart
+@override
+Widget build(BuildContext context) {
+  if (widget.useDossedartDesign) return _buildDossedartCockpit(context);
+  return _buildClassicScaffold(context);
+}
+
+Widget _buildClassicScaffold(BuildContext context) {
+  // …the entire existing build() body, untouched…
+}
+
+Widget _buildDossedartCockpit(BuildContext context) {
+  // Placeholder — Task 11 wires the real cockpit. For now defer to
+  // classic so the app still works during the refactor.
+  return _buildClassicScaffold(context);
+}
+```
+
+- [ ] **Step 10.3: Verify the app still works classically**
+
+```bash
+flutter analyze lib/screens/game_screen.dart
+flutter test test/
+```
+Expected: analyzer clean, all 161 widget tests pass (no behaviour change yet).
+
+- [ ] **Step 10.4: Commit**
+
+```bash
+git add lib/screens/game_screen.dart
+git commit -m "refactor(game_screen): extract classic build, add useDossedartDesign flag stub"
+```
+
+---
+
+## Task 11: Wire setup screen to pass `useDossedartDesign: true`
+
+**Files:**
+- Modify: `lib/screens/dossedart/dossedart_x01_setup_screen.dart`
+
+- [ ] **Step 11.1: Update the GameScreen push**
+
+In `lib/screens/dossedart/dossedart_x01_setup_screen.dart`, find the `Navigator.pushReplacement` block (around line 83) and add the new param:
+
+```dart
+Navigator.pushReplacement(
+  context,
+  MaterialPageRoute(
+    builder: (_) => GameScreen(
+      players: withScore,
+      masterOut: _outRule,
+      startingScore: widget.startingScore,
+      handicap: _handicap,
+      noBust: _noBust,
+      useDossedartDesign: true,
+    ),
+  ),
+);
+```
+
+- [ ] **Step 11.2: Analyze + test**
+
+```bash
+flutter analyze lib/screens/dossedart/dossedart_x01_setup_screen.dart
+flutter test test/
+```
+Expected: clean. (The flag is set to `true` but `_buildDossedartCockpit` still defers to classic, so behaviour is unchanged.)
+
+- [ ] **Step 11.3: Commit**
+
+```bash
+git add lib/screens/dossedart/dossedart_x01_setup_screen.dart
+git commit -m "feat(dossedart): X01 setup passes useDossedartDesign=true to GameScreen"
+```
+
+---
+
+## Task 12: Implement `_buildDossedartCockpit` — wire the widgets
+
+**Files:**
+- Modify: `lib/screens/game_screen.dart`
+
+Replace the placeholder with the real cockpit: `Stack` with `DossedartCrtFrame`, `DossedartX01TopBar` at top, `DossedartX01ActiveCard` in flow, `DossedartX01Dartboard` Positioned in the middle, `DossedartX01ActionBar` Positioned at bottom.
+
+For checkout-tip text, reuse the existing `_checkoutFor(int score)` method (already exists in `_GameScreenState`).
+
+For last-turn label, reuse `_lastDartsLabel(int playerIndex)`.
+
+- [ ] **Step 12.1: Add imports to game_screen.dart**
+
+Near the top of `lib/screens/game_screen.dart`, after existing imports:
+
+```dart
+import '../widgets/dossedart/dossedart_crt_frame.dart';
+import '../widgets/dossedart/x01/dart_zone.dart';
+import '../widgets/dossedart/x01/dossedart_x01_active_card.dart';
+import '../widgets/dossedart/x01/dossedart_x01_action_bar.dart';
+import '../widgets/dossedart/x01/dossedart_x01_dartboard.dart';
+import '../widgets/dossedart/x01/dossedart_x01_topbar.dart';
+import 'dossedart/x01/dossedart_player_overview_screen.dart';
+```
+
+- [ ] **Step 12.2: Replace `_buildDossedartCockpit` body**
+
+Find the placeholder added in Task 10 and replace:
+
+```dart
+Widget _buildDossedartCockpit(BuildContext context) {
+  final player = players[currentPlayerIndex];
+  final lastLabel = _lastDartsLabel(currentPlayerIndex);
+  final tip = _checkoutFor(player.score);
+
+  // Last-turn sum (sum of the three throws ending the previous turn).
+  final lastTurn = throwHistory.where((t) => t.playerIndex == currentPlayerIndex).toList();
+  // Take the last 3 darts BEFORE the current turn (skip darts in progress).
+  // For this iteration we use lastLabel as-is and a 0 sum when unknown.
+  // _lastDartsLabel already produces 'T20 · S20 · S20' style strings.
+  final lastSum = _sumOfLastThreeBeforeCurrentTurn(currentPlayerIndex);
+
+  final title = 'X01 · ${widget.startingScore} · ${_outRuleLabel()}';
+
+  return Scaffold(
+    backgroundColor: const Color(0xFF0A0014),
+    body: DossedartCrtFrame(
+      child: SafeArea(
+        child: Stack(
+          children: [
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                DossedartX01TopBar(
+                  title: title,
+                  legIndex: 1,
+                  legCount: 1,
+                  roundNumber: _currentRound(),
+                  onExit: _confirmExit,
+                ),
+                DossedartX01ActiveCard(
+                  playerName: player.name,
+                  avatarPath: player.avatarPath,
+                  accentColor: const Color(0xFFFF00AA),
+                  remaining: player.score,
+                  currentDartIndex: dartsInTurn,
+                  lastTurnLabel: lastLabel,
+                  lastTurnSum: lastSum,
+                  checkoutTip: tip.isEmpty ? null : tip,
+                ),
+              ],
+            ),
+            // Dartboard — fixed position, never shifts with active card height
+            Positioned(
+              left: 14, right: 14, bottom: 74,
+              child: AspectRatio(
+                aspectRatio: 1,
+                child: Container(
+                  decoration: BoxDecoration(
+                    border: Border.all(color: const Color(0xFFFF00AA), width: 3),
+                    boxShadow: [
+                      BoxShadow(color: const Color(0xFFFF00AA).withValues(alpha: 0.4), blurRadius: 14),
+                    ],
+                  ),
+                  child: DossedartX01Dartboard(
+                    onTap: (zone) {
+                      final (seg, mult) = zone.toSegmentMultiplier();
+                      if (seg == 0) {
+                        _onMiss();
+                      } else {
+                        _onDartHit(seg, mult);
+                      }
+                    },
+                  ),
+                ),
+              ),
+            ),
+            Positioned(
+              left: 0, right: 0, bottom: 0,
+              child: DossedartX01ActionBar(
+                onUndo: _undo,
+                onMiss: _onMiss,
+                onMenu: () => _showDossedartMenu(context),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+String _outRuleLabel() {
+  switch (widget.masterOut) {
+    case 'double': return 'D-OUT';
+    case 'master': return 'MASTER';
+    default: return 'FREE';
+  }
+}
+
+int _currentRound() {
+  // Round number = (total darts thrown by the index-0 player) ~/ 3 + 1.
+  // For multi-player, all players play roughly the same number of rounds.
+  final p0Darts = throwHistory.where((t) => t.playerIndex == 0).length;
+  return (p0Darts ~/ 3) + 1;
+}
+
+int _sumOfLastThreeBeforeCurrentTurn(int playerIndex) {
+  final all = throwHistory.where((t) => t.playerIndex == playerIndex).toList();
+  // Exclude darts in the current in-progress turn (those count toward dartsInTurn).
+  final completedCount = all.length - dartsInTurn;
+  if (completedCount < 3) return 0;
+  final lastThree = all.sublist(completedCount - 3, completedCount);
+  return lastThree.fold(0, (acc, t) => acc + t.segment * t.multiplier);
+}
+
+void _showDossedartMenu(BuildContext outerContext) {
+  showModalBottomSheet(
+    context: outerContext,
+    backgroundColor: const Color(0xFF1A0030),
+    builder: (sheetCtx) {
+      return SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.scoreboard, color: Color(0xFF00E5FF)),
+              title: const Text(
+                'PLAYER OVERVIEW',
+                style: TextStyle(
+                  fontFamily: 'PressStart2P', fontSize: 11, color: Colors.white, letterSpacing: 1.5,
+                ),
+              ),
+              onTap: () {
+                Navigator.pop(sheetCtx);
+                _openPlayerOverview();
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.exit_to_app, color: Color(0xFFFF3050)),
+              title: const Text(
+                'EXIT MATCH',
+                style: TextStyle(
+                  fontFamily: 'PressStart2P', fontSize: 11, color: Colors.white, letterSpacing: 1.5,
+                ),
+              ),
+              onTap: () {
+                Navigator.pop(sheetCtx);
+                _confirmExit();
+              },
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+void _openPlayerOverview() {
+  final rows = <PlayerOverviewRow>[];
+  for (int i = 0; i < players.length; i++) {
+    final p = players[i];
+    final pThrows = throwHistory.where((t) => t.playerIndex == i).toList();
+    final hits = pThrows.where((t) => t.segment != 0).length;
+    final total = pThrows.length;
+    final hitPct = total == 0 ? 0 : (hits * 100 / total).round();
+    final missPct = 100 - hitPct;
+    final pointsSum = pThrows.fold<int>(0, (acc, t) => acc + t.segment * t.multiplier);
+    final avg = total == 0 ? 0.0 : (pointsSum / total) * 3;
+    final lastLabel = _lastDartsLabel(i);
+    final lastSum = _sumOfLastThreeBeforeCurrentTurn(i);
+    rows.add(PlayerOverviewRow(
+      name: p.name,
+      avatarPath: p.avatarPath,
+      remaining: p.score,
+      lastTurnLabel: lastLabel.isEmpty ? '— · — · —' : lastLabel,
+      lastTurnSum: lastSum,
+      avg: avg,
+      hitPct: hitPct,
+      missPct: missPct,
+    ));
+  }
+  Navigator.of(context).push(MaterialPageRoute(
+    builder: (_) => DossedartPlayerOverviewScreen(
+      title: 'CAST · X01 ${widget.startingScore}',
+      roundNumber: _currentRound(),
+      rows: rows,
+    ),
+  ));
+}
+```
+
+Notes:
+- `_lastDartsLabel` already exists on `_GameScreenState` — use as-is.
+- `_checkoutFor` already exists — use as-is.
+- `_confirmExit` already exists.
+- `_onDartHit`, `_onMiss`, `_undo` already exist.
+- The newly-added helpers are `_outRuleLabel`, `_currentRound`, `_sumOfLastThreeBeforeCurrentTurn`, `_showDossedartMenu`, `_openPlayerOverview`. Add them as private methods on `_GameScreenState` (alongside the existing helpers).
+
+- [ ] **Step 12.3: Analyze + verify classic still works**
+
+```bash
+flutter analyze lib/screens/game_screen.dart
+flutter test test/
+```
+Expected: clean + all tests pass.
+
+- [ ] **Step 12.4: Commit**
+
+```bash
+git add lib/screens/game_screen.dart
+git commit -m "feat(dossedart): wire DossedartX01 cockpit into GameScreen"
+```
+
+---
+
+## Task 13: Integration test — cockpit renders + Player Overview navigation
+
+**Files:**
+- Create: `integration_test/dossedart/x01_cockpit_test.dart`
+
+Smoke test: start a DOSSEDART X01 match with 2 seeded players, verify cockpit renders, then open Player Overview via MENU and verify it appears.
+
+- [ ] **Step 13.1: Create the test**
+
+Create `integration_test/dossedart/x01_cockpit_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:dart_scoring/models/player.dart';
+import 'package:dart_scoring/screens/dossedart/x01/dossedart_player_overview_screen.dart';
+import 'package:dart_scoring/screens/game_screen.dart';
+import 'package:dart_scoring/widgets/dossedart/x01/dossedart_x01_dartboard.dart';
+
+import '../helpers/test_app.dart';
+import '../helpers/player_setup.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+      'DOSSEDART X01 cockpit renders + MENU opens Player Overview',
+      (tester) async {
+    await setupTestEnvironment(
+      useDossedartDesign: true,
+      savedPlayers: ['MIA', 'JON'],
+    );
+    final players = buildPlayers(names: ['MIA', 'JON'], startingScore: 501);
+    await pumpScreen(
+      tester,
+      GameScreen(
+        players: players,
+        startingScore: 501,
+        useDossedartDesign: true,
+      ),
+    );
+    await tester.pumpAndSettle(const Duration(seconds: 10));
+
+    // Cockpit renders: name + remaining + dartboard + menu button visible.
+    expect(find.text('MIA'), findsOneWidget);
+    expect(find.text('501'), findsWidgets);
+    expect(find.byType(DossedartX01Dartboard), findsOneWidget);
+    expect(find.text('⋯ MENU'), findsOneWidget);
+
+    // Open MENU → see "PLAYER OVERVIEW" entry.
+    await tester.tap(find.text('⋯ MENU'));
+    await tester.pumpAndSettle(const Duration(seconds: 10));
+    expect(find.text('PLAYER OVERVIEW'), findsOneWidget);
+
+    // Tap PLAYER OVERVIEW → Overview screen appears with both players.
+    await tester.tap(find.text('PLAYER OVERVIEW'));
+    await tester.pumpAndSettle(const Duration(seconds: 10));
+    expect(find.byType(DossedartPlayerOverviewScreen), findsOneWidget);
+    expect(find.text('MIA'), findsOneWidget);
+    expect(find.text('JON'), findsOneWidget);
+  });
+}
+```
+
+- [ ] **Step 13.2: Analyze**
+
+```bash
+flutter analyze integration_test/dossedart/x01_cockpit_test.dart
+```
+Expected: clean.
+
+- [ ] **Step 13.3: Commit**
+
+```bash
+git add integration_test/dossedart/x01_cockpit_test.dart
+git commit -m "test(integration): DOSSEDART X01 cockpit + Player Overview smoke test"
+```
+
+---
+
+## Task 14: Final verification + push + PR
+
+**Files:** none (verification + git)
+
+- [ ] **Step 14.1: Full analyzer + widget tests**
+
+```bash
+flutter analyze
+flutter test test/
+```
+Expected: `No issues found!` + all tests pass.
+
+- [ ] **Step 14.2: Push the branch**
+
+```bash
+git push -u origin feat/dossedart-x01-cockpit
+```
+
+- [ ] **Step 14.3: Open the PR**
+
+```bash
+gh pr create --title "DOSSEDART X01 cockpit + Player Overview (default state)" --body "$(cat <<'EOF'
+## Summary
+
+- DOSSEDART X01 in-game cockpit shipping behind the existing \`use_dossedart_design\` preview flag
+- New widgets under \`lib/widgets/dossedart/x01/\`: TopBar, ActiveCard, Dartboard, ActionBar + shared CrtFrame + PlayerAvatar
+- New \`DossedartPlayerOverviewScreen\` accessible from cockpit MENU
+- \`GameScreen\` branches via new \`useDossedartDesign\` flag; classic logic unchanged
+- Dartboard visual matches hit-test (rings are tappable at their visible width)
+
+Spec: \`docs/superpowers/specs/2026-05-20-dossedart-x01-cockpit-design.md\`
+Plan: \`docs/superpowers/plans/2026-05-20-dossedart-x01-cockpit-plan.md\`
+
+## Out of scope (separate spec)
+
+- BUST, TURN END, MENU (full sheet), SUDDEN DEATH, PLAYER REMOVED, LEG WON, MATCH WON game-states
+- DOSSEDART in-game for Cricket / ATC / Killer / Shanghai / Splitscore
+
+## Test plan
+
+- [x] Widget tests for cockpit components
+- [x] Integration test: cockpit renders + Player Overview navigation
+- [ ] CI green (widget + Android emulator)
+- [ ] Manual: enable DOSSEDART preview, start X01 501, verify cockpit + tap-zones + Player Overview
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Return the PR URL.
+
+---
+
+## Self-review notes
+
+**Spec coverage:**
+- §Architecture (flag plumbing + branch in build) → Task 10
+- §File layout → Tasks 3-9 + 12
+- §Component contracts (TopBar / ActiveCard / Dartboard / ActionBar / Player Overview) → Tasks 5, 6, 8, 7, 9 respectively
+- §Dartboard geometry — visual matches hit-test → Task 8 (radius constants + zone resolver match spec table)
+- §Long-name strategy → Task 6 `_nameFontSize` + Task 9 `_nameFontSize`
+- §Profile pictures → Task 4 + used in Tasks 6 and 9
+- §CRT visual treatment → Task 3 (DossedartCrtFrame wraps existing ArcadeFrame)
+- §Layout invariants (dartboard fixed in Stack) → Task 12 (`Positioned` for board)
+- §Testing (widget tests + integration test) → Tasks 5, 6, 7, 8 + Task 13
+
+**Placeholder scan:** No TBD/TODO. The dartboard geometry table in the spec is implemented verbatim as constants in Task 8. `_outRuleLabel`, `_currentRound`, `_sumOfLastThreeBeforeCurrentTurn`, `_showDossedartMenu`, `_openPlayerOverview` are fully implemented in Task 12.
+
+**Type consistency:** `DartZone` API used identically across Tasks 2, 8, 12. `DossedartPlayerAvatar` signature consistent in Tasks 4, 6, 9. `PlayerOverviewRow` view-model defined in Task 9 and constructed in Task 12.
+
+**Scope check:** Single PR, ~14 commits, all changes inside DOSSEDART namespace + `game_screen.dart`. Reverting any single commit independent of later commits.

--- a/docs/superpowers/specs/2026-05-20-dossedart-x01-cockpit-design.md
+++ b/docs/superpowers/specs/2026-05-20-dossedart-x01-cockpit-design.md
@@ -133,8 +133,34 @@ The active card and dartboard may visually overlap in extreme edge cases (very l
   - Outer label band: dark bg with `Press Start 2P` 11px white segment number
   - Bull outer ring: orange · Bull centre: red
 - Magenta 3px border around the board with glow.
-- Hit-testing uses standard dart geometry (computed angles + radii). Tap outside the outer ring fires `DartZone.miss`.
-- No internal state.
+- No internal state. Hit-test geometry detailed in next section.
+
+### Dartboard geometry — visual vs touch (CRITICAL)
+
+A real dartboard's double and triple rings are very narrow (~5% of total radius each). Rendered at standard proportions on a phone-sized board (~320-370px), each ring is only ~9-17px wide — too narrow to tap reliably.
+
+**Strategy: visual = realistic; hit-test = generous.** The rings are drawn at proportions a player recognises as a dartboard, but the touch-zone radii used by hit-testing are expanded so each ring meets Material's 44dp minimum tap-target where the board allows.
+
+| Ring | Visual outer radius (% of board radius) | Visual width | Hit-test band |
+|---|---|---|---|
+| Inner bull (D-Bull) | 5% | — | 0 → 5% |
+| Outer bull (Bull) | 10% | 5% | 5% → 12% |
+| Inner single | 50% | 38% | 12% → 47% |
+| **Triple** | **55%** | **5%** | **47% → 58%** |
+| Outer single | 85% | 30% | 58% → 82% |
+| **Double** | **92%** | **7%** | **82% → 95%** |
+| Beyond board edge | — | — | 95%+ = miss |
+
+Numbers in **bold** are the rings that need touch-zone expansion past their visual bounds. On a 320px board (radius 160), this gives:
+- Triple visible: ~8px wide → hit-band: ~18px wide
+- Double visible: ~11px wide → hit-band: ~21px wide
+- Single zones still own all remaining radius — slightly compressed by ring expansion, but each is still wide enough that ambiguity is minimal.
+
+**Algorithm:** convert tap (x,y) → polar (r, θ) relative to board centre. Compare `r` against the hit-test band thresholds (not the visual outer-edge radii) to pick the ring. Compare `θ` against segment angles to pick the number. Outside the outermost band → `DartZone.miss`.
+
+This keeps the look authentic but means the user doesn't have to be pixel-precise to register a double or triple.
+
+**Test coverage** for this is mandatory: `dossedart_x01_dartboard_test.dart` includes a fixture of (x, y) tap coordinates spanning visual ring edges, asserting the expected `DartZone` falls correctly under the expanded band.
 
 **`DossedartX01ActionBar`** (stateless):
 - 3 buttons left-to-right:

--- a/docs/superpowers/specs/2026-05-20-dossedart-x01-cockpit-design.md
+++ b/docs/superpowers/specs/2026-05-20-dossedart-x01-cockpit-design.md
@@ -1,0 +1,262 @@
+# DOSSEDART X01 in-game cockpit — design
+
+**Date:** 2026-05-20
+**Target branch:** `feat/dossedart-x01-cockpit` (worktree `.worktrees/dossedart-x01-cockpit`, branched from `main`)
+
+## Problem
+
+DOSSEDART (the arcade-styled design variant, preview flag in Settings) currently has a home screen + 6 setup screens. When a user starts an actual match with DOSSEDART enabled, they're navigated into the classic Material `GameScreen` — splitting the experience. The user has chosen DOSSEDART as one of two main design tracks (the other being classic M3); for that choice to feel coherent, in-game must also be DOSSEDART when the flag is on.
+
+This spec covers the **X01 in-game cockpit (default state)** + an adjoining **Player Overview** screen. The other X01 in-game states (BUST, TURN END, MENU, SUDDEN DEATH, PLAYER REMOVED, LEG WON, MATCH WON) are explicitly out of scope and will be addressed in a follow-up spec.
+
+## Goals
+
+- DOSSEDART X01 in-game cockpit shipping behind the existing `use_dossedart_design` preview flag.
+- Player Overview screen accessible from the cockpit's MENU button — shows all players with remaining, last turn, 3-dart avg, hit%, miss%.
+- Layout invariant: the dartboard's position is fixed; it must not move when the checkout-tip appears/disappears or any other dynamic content changes.
+- Long-name handling: name font auto-shrinks in discrete steps, then ellipsizes; REMAINING never gets pushed out of view.
+- Profile pictures used wherever an avatar appears (silhouette fallback for players without a photo).
+- All existing classic X01 game logic (undo, sudden death detection, stats, TTS, sound, video, mid-game add/remove) is preserved unchanged — DOSSEDART is presentation-only.
+
+## Non-goals
+
+- The 6 special states (BUST, TURN END, MENU, SUDDEN DEATH, PLAYER REMOVED, LEG WON, MATCH WON) — separate spec.
+- DOSSEDART Cricket / ATC / Killer / Shanghai / Splitscore in-game — separate specs (one each).
+- Engine extraction — long-deferred project, NOT prerequisite for this work.
+- Classic GameScreen visual changes — untouched.
+- New gameplay mechanics or stats not already tracked by the existing engine.
+- "Last 5 W/L pips" wiring (separate open thread).
+
+## Reference mockups (committed in repo)
+
+- `docs/design/dossedart-handoff/PROPOSAL-cockpit-v5.html` — cockpit (silhouette + photo variants)
+- `docs/design/dossedart-handoff/PROPOSAL-player-overview-v4.html` — Player Overview (arcade scoreboard)
+
+Both mockups served via `python -m http.server 8765` in the handoff folder.
+
+## Deviations from original handoff (`docs/design/dossedart-handoff/README.md`)
+
+The original handoff describes a player **carousel** with active card + prev/next peek cards. After review the user opted to **drop the carousel** in favour of a single active-player card + a separate Player Overview screen reached from MENU. Reasons:
+
+1. The carousel mixed "browse other players" with "play your turn" in one component, which made the cockpit visually busy.
+2. Player Overview as a separate screen gives more room per player and supports more stats per row.
+
+The original handoff also illustrates a **standard dartboard color convention**. The user chose **DOSSEDART arcade colors on the board** instead, compensating for reduced muscle-memory readability with strong per-segment numeric labels in Press Start 2P.
+
+These deviations are intentional. The original handoff README remains the source of truth for the *visual language* (tokens, type, scanline, glow, etc.); the proposal HTMLs above are the source of truth for *cockpit + overview layout* specifically.
+
+## Architecture
+
+### Routing & flag plumbing
+
+`GameScreen` (`lib/screens/game_screen.dart`) gains a `final bool useDossedartDesign` constructor parameter, default `false`. `build()` becomes:
+
+```dart
+@override
+Widget build(BuildContext context) {
+  if (widget.useDossedartDesign) return _buildDossedartCockpit(context);
+  return _buildClassicScaffold(context); // existing body, extracted unchanged
+}
+```
+
+The existing build tree is moved verbatim into `_buildClassicScaffold(context)` — no semantic change. The new `_buildDossedartCockpit(context)` builds the cockpit using shared `_GameScreenState` for all logic.
+
+`lib/screens/dossedart/dossedart_x01_setup_screen.dart`: when pushing `GameScreen` on Start, passes `useDossedartDesign: true`.
+
+`lib/screens/player_setup_screen.dart` (classic): no change needed (defaults to `false`).
+
+### File layout
+
+**New files:**
+
+```
+lib/widgets/dossedart/x01/
+  dossedart_x01_topbar.dart          — ◀ EXIT · title · L 1/3 · RND 7
+  dossedart_x01_active_card.dart     — avatar + name + dart-dots + REMAINING + LAST + checkout-tip
+  dossedart_x01_dartboard.dart       — tap-zone SVG dartboard in arcade colors
+  dossedart_x01_action_bar.dart      — UNDO · MISS · MENU
+
+lib/screens/dossedart/x01/
+  dossedart_player_overview_screen.dart   — arcade scoreboard view, pushed from MENU
+```
+
+**Modified files:**
+
+- `lib/screens/game_screen.dart` — adds `useDossedartDesign` param + `_buildDossedartCockpit()` branch; extracts existing build into `_buildClassicScaffold()`. No logic changes.
+- `lib/screens/dossedart/dossedart_x01_setup_screen.dart` — passes `useDossedartDesign: true` when pushing GameScreen.
+
+No new state, no new model fields, no engine changes.
+
+### Layout structure (cockpit)
+
+The cockpit is a `Stack` (not Column) so the dartboard's position is invariant:
+
+```
+Stack (fills screen)
+├── Column (header + active card, flows from top — bounded by Positioned top:0)
+│   ├── DossedartX01TopBar          height ~49px
+│   └── DossedartX01ActiveCard      variable height (~220-260px depending on checkout-tip)
+├── Positioned (bottom: 84+actionbar, centered horizontally)
+│   └── DossedartX01Dartboard       fixed 320x320 (or scaled to viewport width)
+└── Positioned (bottom: 0)
+    └── DossedartX01ActionBar       height ~60px
+```
+
+The **active card's variable height does NOT push the dartboard** because the dartboard is a separate `Positioned` child of the same `Stack`. Critical: do NOT nest dartboard inside a `Column` with the active card.
+
+The active card and dartboard may visually overlap in extreme edge cases (very long checkout-tip + very large remaining number); the active card's `Container` clips its own content and the dartboard remains underneath. If overlap is observed during implementation, the active card's max-height is capped via `ConstrainedBox`.
+
+### Component contracts
+
+**`DossedartX01TopBar`** (stateless):
+- Inputs: `String mode`, `int startingScore`, `String outRule`, `int legIndex`, `int legCount`, `int roundNumber`, `VoidCallback onExit`
+- Renders: `◀ EXIT` (cyan, left) · centered title `X01 · {score} · {outRule}` (yellow, glow, ellipsizes) · `L {n}/{m} · RND {r}` (right, dim)
+- Magenta 2px bottom border. Always-uppercase content.
+
+**`DossedartX01ActiveCard`** (stateless):
+- Inputs: `Player player` (name, avatarPath), `Color accent` (magenta default; opens room for per-player colour later), `int remaining`, `List<DartThrow> lastTurnThrows`, `int currentDartIndex` (0-2), `String? checkoutTip` (null = no checkout possible)
+- Layout: 3px magenta border, gradient bg, padding 12/14
+  - Row 1: 56px square `PlayerAvatar` + name (Press Start 2P, auto-shrinks: 18/15/12/10px, ellipsizes) + dart-dots row
+  - Dart-dots: 3 squares (●/○) under the name, `DART {n}/3` VT323 caption
+  - Row 2: `REMAINING` label (small) + big remaining number (Press Start 2P 60px, magenta, glow + chromatic-aberration)
+  - Row 3 (above dashed magenta separator): `LAST` label + 3 throws (VT323 yellow) + `= sum` (Press Start 2P yellow)
+  - Row 4 (only when `checkoutTip != null`): green dashed-border strip showing the tip
+- No internal state. Pure props.
+
+**`DossedartX01Dartboard`** (stateless):
+- Inputs: `void Function(DartZone zone) onTap` (zone = S/D/T per segment + Bull/D-Bull + miss)
+- Renders SVG/CustomPainter: 20 segments in standard ordering (20,1,18,4,13,6,10,15,2,17,3,19,7,16,8,11,14,9,12,5), arcade colors:
+  - Inner singles: alternating magenta/cyan (opacity 0.35)
+  - Triple ring: solid green
+  - Outer singles: alternating magenta/cyan (opacity 0.35)
+  - Double ring: solid yellow
+  - Outer label band: dark bg with `Press Start 2P` 11px white segment number
+  - Bull outer ring: orange · Bull centre: red
+- Magenta 3px border around the board with glow.
+- Hit-testing uses standard dart geometry (computed angles + radii). Tap outside the outer ring fires `DartZone.miss`.
+- No internal state.
+
+**`DossedartX01ActionBar`** (stateless):
+- 3 buttons left-to-right:
+  - `↶ UNDO` — flex 1, magenta border, transparent bg, white text
+  - `✗ MISS` — flex 2, filled orange bg, white border, glow (primary)
+  - `⋯ MENU` — flex 1, cyan border, cyan text
+- Black bg, yellow 2px top border. Press Start 2P 11px.
+- Inputs: `VoidCallback onUndo`, `VoidCallback onMiss`, `VoidCallback onMenu`
+
+**`DossedartPlayerOverviewScreen`** (stateful screen — pushed by MENU; can also be reached via "Player Overview" menu entry):
+- Inputs: `List<Player> players`, `int currentPlayerIndex`, `String mode`, `int startingScore`, `int currentRound`
+- Renders:
+  - TopBar (back, title `CAST · X01 {score}`, `RND {r}`)
+  - `► SCOREBOARD ◄` magenta marquee
+  - Column header: `# | (avatar) | PLAYER | REMAIN`
+  - Scrollable list — one row per player:
+    - Line 1: rank `01..NN` (yellow Press Start 2P) · 44px square `PlayerAvatar` · name (auto-shrinks 14/12/10px, ellipsizes) · `REMAINING` (magenta Press Start 2P 26px)
+    - Line 2 (small, dim): `AVG {x.x} · HIT {y}%`
+    - Line 3 (yellow-tinted box): `LAST {throws} {sum}` — fills full row width
+  - Bottom marquee: `★ ★ ★ INSERT DART TO CONTINUE ★ ★ ★` (cyan, decorative)
+- Hit % derived from existing throw history (`hits / totalDarts`); miss % = 100 - hit%.
+- Active player is NOT highlighted (per user feedback — all rows look uniform).
+
+### CRT visual treatment (applies to both cockpit and overview)
+
+These are shared treatments, implemented once in a `DossedartCrtFrame` widget that wraps the screen body:
+
+- **Background:** `DossedartTokens.bg`
+- **Scanlines:** repeating 3px-period horizontal lines (rgba 0,0,0,0.40 in line)
+- **Vignette:** radial gradient at 40-100% darkening to rgba 0,0,0,0.75
+- **Inset shadows:** `BoxShadow(blurRadius: 60, color: black87, offset zero)` simulating CRT-glass-bulge
+- **Border-radius 16** on the inner frame
+- **Text glow:** all UI accent text uses `Shadows` with blur 6-16px in the colour itself plus a small +1px magenta / -1px cyan chromatic-aberration ghost on big text and titles
+- **Scan-beam animation:** the existing `ArcadeFrame` widget (used by setup screens) already provides the slow scanning beam; cockpit reuses it inside `DossedartCrtFrame`. Tests use the `disableBeamForTest` flag added in PR #7.
+
+The "CRT bezel" shown in the mockup (grey plastic surround with rounded corners + power LED) is **decorative-only in the mockup** and is NOT implemented in Flutter — it would shrink usable screen area. In Flutter the bezel-style is conveyed entirely by inset shadows + border-radius on the inner frame.
+
+### Dart input flow
+
+The dartboard's `onTap(DartZone)` triggers the existing private method that classic uses to register a dart hit. The exact entry point is `_GameScreenState._onDartHit(int segment, int multiplier)` (around line 278) — DOSSEDART maps `DartZone` → `(segment, multiplier)` and calls the same method. No new logic, no new state machine.
+
+Currently classic uses a numeric keypad; DOSSEDART uses tap-zones on the dartboard. Both feed into the same `_onDartHit`. Sudden death, bust detection, checkout detection — all unchanged.
+
+The `↶ UNDO` button calls existing `_undo()`. The `✗ MISS` button calls `_onMiss()` (already exists). The `⋯ MENU` button — for this spec — opens a temporary bottom sheet with two actions:
+
+1. **Player Overview** — navigates to `DossedartPlayerOverviewScreen`
+2. **Exit match** — same as classic's confirm-exit flow
+
+The richer MENU sheet from the original handoff (with EDIT LAST THROW, REMOVE PLAYER, RESTART LEG, ABANDON MATCH) is **deferred to the next spec** which covers the 7 states.
+
+### Long-name strategy
+
+Per the cockpit V4 mockup, name font auto-shrinks in 4 discrete steps:
+
+| Length (chars) | Active card | Overview list |
+|---|---|---|
+| ≤6 | 18px | 14px |
+| 7-10 | 15px | 12px |
+| 11-16 | 12px | 10px |
+| 17+ | 10px + ellipsis | 10px + ellipsis |
+
+REMAINING is always rendered last in its row and never shrinks — it always wins layout priority.
+
+### Profile pictures
+
+`DossedartX01ActiveCard` and `DossedartPlayerOverviewScreen` use the existing `PlayerAvatar` widget (`lib/widgets/player_avatar.dart`) with:
+- `radius: 28` for active card (yields 56px diameter)
+- `radius: 22` for overview rows (yields 44px diameter)
+
+The current `PlayerAvatar` uses `CircleAvatar` (round). For arcade aesthetic, a **square wrapper** is needed. Two options:
+
+1. Add a `bool square = false` param to `PlayerAvatar` — minimal invasion, but couples the avatar widget to arcade concerns.
+2. Create a thin `DossedartPlayerAvatar` widget that composes `PlayerAvatar` inside a square `Container` (clipping the round avatar to a square — actually visible as a square with the circle photo inside).
+
+**Decision: Option 2.** Keep `PlayerAvatar` unchanged. New `DossedartPlayerAvatar` wraps it in a square `Container` with player-color border and 0 border-radius. The existing setup-screen picker tiles can be migrated to this new widget in a follow-up if visual consistency matters (not in this spec's scope).
+
+The mockup shows full square photo treatment with `border-radius: 0` (no inset round photo). For implementation, decide between:
+- (a) `CircleAvatar` cropped square → photo shows as full square photo (current PlayerAvatar uses Circle)
+- (b) Custom `Image.file` directly with `BoxFit.cover` inside the square container — gives true square photo.
+
+**Decision: (b)** for `DossedartPlayerAvatar` so the photo IS the square content, no round inset. Implementation reads `avatarPath` directly with `FileImage` + fallback `Icons.person` SVG-style silhouette.
+
+## Layout invariants (must hold in implementation)
+
+1. **Dartboard position is fixed.** Implemented as a separate `Positioned` child of the cockpit `Stack`. Never inside a flow `Column` with the active card.
+2. **Active card max-width = frame minus 14px horizontal padding on each side.**
+3. **REMAINING never overflows.** Always last in its row, `flex: 0 0 auto`, font fixed at 60px.
+4. **Action bar always at bottom.** `Positioned(bottom: 0)`.
+
+## Testing
+
+**Widget tests** (`test/widgets/dossedart/x01/`):
+- `dossedart_x01_active_card_test.dart` — renders with all name-length tiers, checkout-tip present/absent, fallback silhouette vs photo
+- `dossedart_x01_dartboard_test.dart` — tap-zone hit testing: tap at known coords → expect the right `DartZone` event
+- `dossedart_x01_action_bar_test.dart` — button callbacks fire
+
+**Integration test** (`integration_test/dossedart/x01_cockpit_test.dart`):
+- Start a DOSSEDART X01 match with 2 seeded players → cockpit renders, name visible, REMAINING shows starting score, dartboard visible.
+- Smoke: tap MENU → bottom sheet appears → tap "Player Overview" → DossedartPlayerOverviewScreen renders with both players' rows.
+
+**Manual verification (one-time):**
+- Open on actual Galaxy Tab + a phone profile, verify dartboard stays put when toggling checkout-tip visibility via test hook.
+- Open with a long-name player ("BJØRN TORJUS ILESTAD") — verify ellipsis, no REMAINING shift.
+
+## Out of scope
+
+- The 7 game states (BUST, TURN END, MENU [full sheet], SUDDEN DEATH, PLAYER REMOVED, LEG WON, MATCH WON) — next spec
+- Cricket / ATC / Killer / Shanghai / Splitscore in-game DOSSEDART
+- Sound/TTS changes — existing announcer continues to work as-is
+- Performance optimisations (we accept the existing GameScreen perf profile)
+- Animation refinements beyond what's already in `ArcadeFrame`
+- iOS/desktop-specific layout adjustments
+
+## Commit plan
+
+Single PR `feat/dossedart-x01-cockpit` with logical commits:
+
+1. `feat(dossedart): DossedartCrtFrame + DossedartPlayerAvatar foundation`
+2. `feat(dossedart): X01 cockpit widgets (topbar, active card, dartboard, action bar)`
+3. `feat(dossedart): wire X01 setup → GameScreen with useDossedartDesign flag`
+4. `feat(dossedart): Player Overview screen accessible from cockpit MENU`
+5. `test(dossedart): widget tests for cockpit components`
+6. `test(integration): DOSSEDART X01 cockpit + Player Overview navigation smoke test`
+
+If any commit fails analyzer/tests, do not advance.

--- a/docs/superpowers/specs/2026-05-20-dossedart-x01-cockpit-design.md
+++ b/docs/superpowers/specs/2026-05-20-dossedart-x01-cockpit-design.md
@@ -135,32 +135,37 @@ The active card and dartboard may visually overlap in extreme edge cases (very l
 - Magenta 3px border around the board with glow.
 - No internal state. Hit-test geometry detailed in next section.
 
-### Dartboard geometry — visual vs touch (CRITICAL)
+### Dartboard geometry — visual matches hit-test (CRITICAL)
 
 A real dartboard's double and triple rings are very narrow (~5% of total radius each). Rendered at standard proportions on a phone-sized board (~320-370px), each ring is only ~9-17px wide — too narrow to tap reliably.
 
-**Strategy: visual = realistic; hit-test = generous.** The rings are drawn at proportions a player recognises as a dartboard, but the touch-zone radii used by hit-testing are expanded so each ring meets Material's 44dp minimum tap-target where the board allows.
+**Strategy: visual = hit-test.** What the player SEES is what the player CAN TAP. Rings are rendered thicker than a physical board so each one is a comfortable touch target, and the visible boundary IS the hit-test boundary. No "tap a single, register a double" surprises.
 
-| Ring | Visual outer radius (% of board radius) | Visual width | Hit-test band |
+This sacrifices physical realism for input honesty. The board is still recognisable as a dartboard from segment ordering, colours, and the bull centre — the rings are just chunkier.
+
+| Ring | Outer radius (% of board radius) | Width | Notes |
 |---|---|---|---|
-| Inner bull (D-Bull) | 5% | — | 0 → 5% |
-| Outer bull (Bull) | 10% | 5% | 5% → 12% |
-| Inner single | 50% | 38% | 12% → 47% |
-| **Triple** | **55%** | **5%** | **47% → 58%** |
-| Outer single | 85% | 30% | 58% → 82% |
-| **Double** | **92%** | **7%** | **82% → 95%** |
-| Beyond board edge | — | — | 95%+ = miss |
+| D-Bull (inner bull) | 5% | 5% | centre circle |
+| Bull (outer bull) | 12% | 7% | thin ring |
+| Inner single | 47% | 35% | broad band |
+| **Triple** | **58%** | **11%** | ~2× a real triple |
+| Outer single | 82% | 24% | broad band |
+| **Double** | **95%** | **13%** | ~2× a real double |
+| Outer label band | 100% | 5% | visual chrome only — taps here count as `DartZone.miss` (it's outside the playable area on a real board too) |
 
-Numbers in **bold** are the rings that need touch-zone expansion past their visual bounds. On a 320px board (radius 160), this gives:
-- Triple visible: ~8px wide → hit-band: ~18px wide
-- Double visible: ~11px wide → hit-band: ~21px wide
-- Single zones still own all remaining radius — slightly compressed by ring expansion, but each is still wide enough that ambiguity is minimal.
+Numbers in **bold** are wider than a physical board. The outer 5% is a non-tappable label band where the segment number is rendered (matches the cosmetic ring on real boards just outside the double).
 
-**Algorithm:** convert tap (x,y) → polar (r, θ) relative to board centre. Compare `r` against the hit-test band thresholds (not the visual outer-edge radii) to pick the ring. Compare `θ` against segment angles to pick the number. Outside the outermost band → `DartZone.miss`.
+On a 320px board (radius 160), this gives:
+- Triple: ~18px wide ring — both visually and to tap
+- Double: ~21px wide ring — both visually and to tap
 
-This keeps the look authentic but means the user doesn't have to be pixel-precise to register a double or triple.
+**Algorithm:** convert tap (x,y) → polar (r, θ) relative to board centre. Compare `r` against the radius thresholds in the table to pick the ring. Compare `θ` against segment angles to pick the number. Tap with `r > 95% × board-radius` → `DartZone.miss`.
 
-**Test coverage** for this is mandatory: `dossedart_x01_dartboard_test.dart` includes a fixture of (x, y) tap coordinates spanning visual ring edges, asserting the expected `DartZone` falls correctly under the expanded band.
+**Test coverage** for this is mandatory: `dossedart_x01_dartboard_test.dart` includes a fixture of (x, y) tap coordinates at the inner and outer edges of each ring, asserting the expected `DartZone` falls correctly. Particular cases:
+- 1px inside double-ring outer edge → `DartZone.double(n)`
+- 1px outside double-ring outer edge → `DartZone.miss`
+- 1px inside triple-ring → `DartZone.triple(n)`
+- Anywhere within Bull radius → `DartZone.bull` / `DartZone.dBull`
 
 **`DossedartX01ActionBar`** (stateless):
 - 3 buttons left-to-right:

--- a/integration_test/dossedart/x01_cockpit_test.dart
+++ b/integration_test/dossedart/x01_cockpit_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:dart_scoring/screens/dossedart/x01/dossedart_player_overview_screen.dart';
+import 'package:dart_scoring/screens/game_screen.dart';
+import 'package:dart_scoring/widgets/dossedart/x01/dossedart_x01_dartboard.dart';
+
+import '../helpers/test_app.dart';
+import '../helpers/player_setup.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+      'DOSSEDART X01 cockpit renders + MENU opens Player Overview',
+      (tester) async {
+    await setupTestEnvironment(
+      useDossedartDesign: true,
+      savedPlayers: ['MIA', 'JON'],
+    );
+    final players = buildPlayers(names: ['MIA', 'JON'], startingScore: 501);
+    await pumpScreen(
+      tester,
+      GameScreen(
+        players: players,
+        startingScore: 501,
+        useDossedartDesign: true,
+      ),
+    );
+    await tester.pumpAndSettle(const Duration(seconds: 10));
+
+    // Cockpit renders: name + remaining + dartboard + menu button visible.
+    expect(find.text('MIA'), findsOneWidget);
+    expect(find.text('501'), findsWidgets);
+    expect(find.byType(DossedartX01Dartboard), findsOneWidget);
+    expect(find.text('⋯ MENU'), findsOneWidget);
+
+    // Open MENU → see "PLAYER OVERVIEW" entry.
+    await tester.tap(find.text('⋯ MENU'));
+    await tester.pumpAndSettle(const Duration(seconds: 10));
+    expect(find.text('PLAYER OVERVIEW'), findsOneWidget);
+
+    // Tap PLAYER OVERVIEW → Overview screen appears with both players.
+    await tester.tap(find.text('PLAYER OVERVIEW'));
+    await tester.pumpAndSettle(const Duration(seconds: 10));
+    expect(find.byType(DossedartPlayerOverviewScreen), findsOneWidget);
+    expect(find.text('MIA'), findsOneWidget);
+    expect(find.text('JON'), findsOneWidget);
+  });
+}

--- a/lib/screens/dossedart/dossedart_x01_setup_screen.dart
+++ b/lib/screens/dossedart/dossedart_x01_setup_screen.dart
@@ -89,6 +89,7 @@ class _DossedartX01SetupScreenState extends State<DossedartX01SetupScreen> {
           startingScore: widget.startingScore,
           handicap: _handicap,
           noBust: _noBust,
+          useDossedartDesign: true,
         ),
       ),
     );

--- a/lib/screens/dossedart/x01/dossedart_player_overview_screen.dart
+++ b/lib/screens/dossedart/x01/dossedart_player_overview_screen.dart
@@ -1,0 +1,305 @@
+import 'package:flutter/material.dart';
+import '../../../theme/dossedart_tokens.dart';
+import '../../../widgets/dossedart/dossedart_crt_frame.dart';
+import '../../../widgets/dossedart/dossedart_player_avatar.dart';
+
+/// View-model for one player row in the overview.
+class PlayerOverviewRow {
+  const PlayerOverviewRow({
+    required this.name,
+    required this.avatarPath,
+    required this.remaining,
+    required this.lastTurnLabel,
+    required this.lastTurnSum,
+    required this.avg,
+    required this.hitPct,
+    required this.missPct,
+  });
+
+  final String name;
+  final String? avatarPath;
+  final int remaining;
+  final String lastTurnLabel; // e.g., 'T20 · S20 · S20' or '— · — · —'
+  final int lastTurnSum;
+  final double avg;
+  final int hitPct;
+  final int missPct;
+}
+
+class DossedartPlayerOverviewScreen extends StatelessWidget {
+  const DossedartPlayerOverviewScreen({
+    super.key,
+    required this.title,
+    required this.roundNumber,
+    required this.rows,
+  });
+
+  final String title; // e.g., 'CAST · X01 501'
+  final int roundNumber;
+  final List<PlayerOverviewRow> rows;
+
+  static double _nameFontSize(int len) {
+    if (len <= 6) return 14;
+    if (len <= 10) return 12;
+    return 10;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: DossedartTokens.bg,
+      body: DossedartCrtFrame(
+        child: SafeArea(
+          child: Column(
+            children: [
+              _TopBar(title: title, roundNumber: roundNumber),
+              const _Marquee(text: '► SCOREBOARD ◄'),
+              const _ColHeader(),
+              Expanded(
+                child: ListView.builder(
+                  padding: const EdgeInsets.fromLTRB(14, 6, 14, 14),
+                  itemCount: rows.length,
+                  itemBuilder: (ctx, i) => _Row(rank: i + 1, data: rows[i]),
+                ),
+              ),
+              const _FooterMarquee(text: '★ ★ ★ INSERT DART TO CONTINUE ★ ★ ★'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TopBar extends StatelessWidget {
+  const _TopBar({required this.title, required this.roundNumber});
+  final String title;
+  final int roundNumber;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: const BoxDecoration(
+        color: Colors.black,
+        border: Border(bottom: BorderSide(color: DossedartTokens.magenta, width: 2)),
+      ),
+      child: Row(
+        children: [
+          GestureDetector(
+            onTap: () => Navigator.of(context).pop(),
+            child: const Text(
+              '◀ BACK',
+              style: TextStyle(
+                fontFamily: 'VT323', fontSize: 18, color: DossedartTokens.cyan,
+                letterSpacing: 2, height: 1,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Center(
+              child: Text(
+                title,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  fontFamily: 'PressStart2P', fontSize: 11, color: DossedartTokens.yellow,
+                  letterSpacing: 2,
+                ),
+              ),
+            ),
+          ),
+          Text(
+            'RND $roundNumber',
+            style: const TextStyle(
+              fontFamily: 'VT323', fontSize: 14, color: Colors.white54, letterSpacing: 2,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Marquee extends StatelessWidget {
+  const _Marquee({required this.text});
+  final String text;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.4),
+        border: const Border(bottom: BorderSide(color: Color(0x66FF00AA), width: 1)),
+      ),
+      child: Text(
+        text,
+        textAlign: TextAlign.center,
+        style: const TextStyle(
+          fontFamily: 'PressStart2P',
+          fontSize: 12,
+          color: DossedartTokens.magenta,
+          letterSpacing: 4,
+        ),
+      ),
+    );
+  }
+}
+
+class _ColHeader extends StatelessWidget {
+  const _ColHeader();
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(18, 8, 18, 6),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: Color(0x4D00E5FF), width: 1)),
+      ),
+      child: const Row(
+        children: [
+          SizedBox(width: 32, child: Text('#', style: _hStyle)),
+          SizedBox(width: 54),
+          Expanded(child: Text('PLAYER', style: _hStyle)),
+          Text('REMAIN', style: _hStyle),
+        ],
+      ),
+    );
+  }
+
+  static const _hStyle = TextStyle(
+    fontFamily: 'PressStart2P', fontSize: 8, color: DossedartTokens.cyan,
+    letterSpacing: 1.5,
+  );
+}
+
+class _Row extends StatelessWidget {
+  const _Row({required this.rank, required this.data});
+  final int rank;
+  final PlayerOverviewRow data;
+
+  @override
+  Widget build(BuildContext context) {
+    final nameSize = DossedartPlayerOverviewScreen._nameFontSize(data.name.length);
+    return Container(
+      padding: const EdgeInsets.fromLTRB(4, 10, 4, 12),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: Color(0x2EFFFFFF), width: 1)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Line 1: rank | avatar | name | remaining
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              SizedBox(
+                width: 32,
+                child: Text(
+                  rank.toString().padLeft(2, '0'),
+                  style: const TextStyle(
+                    fontFamily: 'PressStart2P', fontSize: 16,
+                    color: DossedartTokens.yellow, letterSpacing: 1,
+                  ),
+                ),
+              ),
+              DossedartPlayerAvatar(
+                avatarPath: data.avatarPath,
+                size: 44,
+                borderColor: DossedartTokens.magenta,
+                borderWidth: 2,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  data.name,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontFamily: 'PressStart2P', fontSize: nameSize, color: Colors.white,
+                    letterSpacing: nameSize >= 13 ? 2 : 1.2,
+                  ),
+                ),
+              ),
+              Text(
+                '${data.remaining}',
+                style: const TextStyle(
+                  fontFamily: 'PressStart2P', fontSize: 26,
+                  color: DossedartTokens.magenta, letterSpacing: 1, height: 1,
+                ),
+              ),
+            ],
+          ),
+          // Line 2: AVG · HIT%
+          Padding(
+            padding: const EdgeInsets.only(left: 88, top: 8),
+            child: Text(
+              'AVG ${data.avg.toStringAsFixed(1)} · HIT ${data.hitPct}%',
+              style: const TextStyle(
+                fontFamily: 'VT323', fontSize: 16, color: Colors.white60, letterSpacing: 1.5,
+              ),
+            ),
+          ),
+          // Line 3: LAST throws (full width)
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            decoration: BoxDecoration(
+              color: DossedartTokens.yellow.withValues(alpha: 0.08),
+              border: Border.all(color: DossedartTokens.yellow.withValues(alpha: 0.35), width: 1),
+            ),
+            child: Row(
+              children: [
+                const Text(
+                  'LAST',
+                  style: TextStyle(
+                    fontFamily: 'PressStart2P', fontSize: 8,
+                    color: Color(0xA6FFD200), letterSpacing: 1,
+                  ),
+                ),
+                Expanded(
+                  child: Text(
+                    data.lastTurnLabel,
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      fontFamily: 'VT323', fontSize: 22, letterSpacing: 2,
+                      color: DossedartTokens.yellow,
+                    ),
+                  ),
+                ),
+                Text(
+                  '${data.lastTurnSum}',
+                  style: const TextStyle(
+                    fontFamily: 'PressStart2P', fontSize: 12,
+                    color: DossedartTokens.yellow,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FooterMarquee extends StatelessWidget {
+  const _FooterMarquee({required this.text});
+  final String text;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      decoration: const BoxDecoration(
+        color: Colors.black,
+        border: Border(top: BorderSide(color: Color(0x6600E5FF), width: 1)),
+      ),
+      child: Text(
+        text,
+        textAlign: TextAlign.center,
+        style: const TextStyle(
+          fontFamily: 'PressStart2P', fontSize: 9, color: DossedartTokens.cyan,
+          letterSpacing: 3,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -1522,8 +1522,9 @@ class _GameScreenState extends State<GameScreen> {
 
   int _sumOfLastThreeBeforeCurrentTurn(int playerIndex) {
     final all = throwHistory.where((t) => t.playerIndex == playerIndex).toList();
-    // Exclude darts in the current in-progress turn (those count toward dartsInTurn).
-    final completedCount = all.length - dartsInTurn;
+    // Exclude darts in the current in-progress turn only for the active player.
+    final inTurn = playerIndex == currentPlayerIndex ? dartsInTurn : 0;
+    final completedCount = all.length - inTurn;
     if (completedCount < 3) return 0;
     final lastThree = all.sublist(completedCount - 3, completedCount);
     return lastThree.fold(0, (acc, t) => acc + t.segment * t.multiplier);

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -31,6 +31,7 @@ class GameScreen extends StatefulWidget {
   final int startingScore;
   final bool handicap;
   final bool noBust;
+  final bool useDossedartDesign;
 
   const GameScreen({
     super.key,
@@ -39,6 +40,7 @@ class GameScreen extends StatefulWidget {
     required this.startingScore,
     this.handicap = false,
     this.noBust = false,
+    this.useDossedartDesign = false,
   });
 
   @override
@@ -1415,6 +1417,17 @@ class _GameScreenState extends State<GameScreen> {
 
   @override
   Widget build(BuildContext context) {
+    if (widget.useDossedartDesign) return _buildDossedartCockpit(context);
+    return _buildClassicScaffold(context);
+  }
+
+  Widget _buildDossedartCockpit(BuildContext context) {
+    // Placeholder — Task 12 wires the real cockpit. For now defer to
+    // classic so the app still works during the refactor.
+    return _buildClassicScaffold(context);
+  }
+
+  Widget _buildClassicScaffold(BuildContext context) {
     final currentPlayer = players[currentPlayerIndex];
 
     return Scaffold(

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -28,6 +28,7 @@ import '../widgets/dossedart/x01/dossedart_x01_action_bar.dart';
 import '../widgets/dossedart/x01/dossedart_x01_dartboard.dart';
 import '../widgets/dossedart/x01/dossedart_x01_topbar.dart';
 import 'dossedart/x01/dossedart_player_overview_screen.dart';
+import '../theme/dossedart_tokens.dart';
 
 enum _ThrowOutcome { continueTurn, finish, turnEndNoBust, bust }
 
@@ -1101,6 +1102,24 @@ class _GameScreenState extends State<GameScreen> {
     return last3.map((t) => t.shortLabel).join(' \u00b7 ');
   }
 
+  /// Returns the label for the player's previously COMPLETED turn (the
+  /// 3 darts before the current in-progress turn). Empty if there are
+  /// fewer than 3 completed darts.
+  String _previousTurnLabel(int playerIndex) {
+    final all = throwHistory.where((t) => t.playerIndex == playerIndex).toList();
+    final inTurn = playerIndex == currentPlayerIndex ? dartsInTurn : 0;
+    final completedCount = all.length - inTurn;
+    if (completedCount < 3) return '';
+    final lastThree = all.sublist(completedCount - 3, completedCount);
+    return lastThree
+        .map((t) {
+          if (t.segment == 0) return 'MISS';
+          final prefix = t.multiplier == 2 ? 'D' : t.multiplier == 3 ? 'T' : 'S';
+          return '$prefix${t.segment}';
+        })
+        .join(' · ');
+  }
+
   void _undo() {
     if (throwHistory.isEmpty) return;
     _announcer.announceGameEvent('Back');
@@ -1429,7 +1448,7 @@ class _GameScreenState extends State<GameScreen> {
 
   Widget _buildDossedartCockpit(BuildContext context) {
     final player = players[currentPlayerIndex];
-    final lastLabel = _lastDartsLabel(currentPlayerIndex);
+    final lastLabel = _previousTurnLabel(currentPlayerIndex);
     final tip = _checkoutFor(player.score);
 
     // Last-turn sum (sum of the three throws ending the previous turn).
@@ -1438,7 +1457,7 @@ class _GameScreenState extends State<GameScreen> {
     final title = 'X01 · ${widget.startingScore} · ${_outRuleLabel()}';
 
     return Scaffold(
-      backgroundColor: const Color(0xFF0A0014),
+      backgroundColor: DossedartTokens.bg,
       body: DossedartCrtFrame(
         child: SafeArea(
           child: Stack(
@@ -1451,13 +1470,13 @@ class _GameScreenState extends State<GameScreen> {
                     title: title,
                     legIndex: 1,
                     legCount: 1,
-                    roundNumber: _currentRound(),
+                    roundNumber: _roundNumber + 1,
                     onExit: _confirmExit,
                   ),
                   DossedartX01ActiveCard(
                     playerName: player.name,
                     avatarPath: player.avatarPath,
-                    accentColor: const Color(0xFFFF00AA),
+                    accentColor: DossedartTokens.magenta,
                     remaining: player.score,
                     currentDartIndex: dartsInTurn,
                     lastTurnLabel: lastLabel.isEmpty ? null : lastLabel,
@@ -1473,9 +1492,9 @@ class _GameScreenState extends State<GameScreen> {
                   aspectRatio: 1,
                   child: Container(
                     decoration: BoxDecoration(
-                      border: Border.all(color: const Color(0xFFFF00AA), width: 3),
+                      border: Border.all(color: DossedartTokens.magenta, width: 3),
                       boxShadow: [
-                        BoxShadow(color: const Color(0xFFFF00AA).withValues(alpha: 0.4), blurRadius: 14),
+                        BoxShadow(color: DossedartTokens.magenta.withValues(alpha: 0.4), blurRadius: 14),
                       ],
                     ),
                     child: DossedartX01Dartboard(
@@ -1514,12 +1533,6 @@ class _GameScreenState extends State<GameScreen> {
     }
   }
 
-  int _currentRound() {
-    // Round number = (total darts thrown by the index-0 player) ~/ 3 + 1.
-    final p0Darts = throwHistory.where((t) => t.playerIndex == 0).length;
-    return (p0Darts ~/ 3) + 1;
-  }
-
   int _sumOfLastThreeBeforeCurrentTurn(int playerIndex) {
     final all = throwHistory.where((t) => t.playerIndex == playerIndex).toList();
     // Exclude darts in the current in-progress turn only for the active player.
@@ -1533,14 +1546,14 @@ class _GameScreenState extends State<GameScreen> {
   void _showDossedartMenu(BuildContext outerContext) {
     showModalBottomSheet(
       context: outerContext,
-      backgroundColor: const Color(0xFF1A0030),
+      backgroundColor: DossedartTokens.surface,
       builder: (sheetCtx) {
         return SafeArea(
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
               ListTile(
-                leading: const Icon(Icons.scoreboard, color: Color(0xFF00E5FF)),
+                leading: const Icon(Icons.scoreboard, color: DossedartTokens.cyan),
                 title: const Text(
                   'PLAYER OVERVIEW',
                   style: TextStyle(
@@ -1553,7 +1566,7 @@ class _GameScreenState extends State<GameScreen> {
                 },
               ),
               ListTile(
-                leading: const Icon(Icons.exit_to_app, color: Color(0xFFFF3050)),
+                leading: const Icon(Icons.exit_to_app, color: DossedartTokens.red),
                 title: const Text(
                   'EXIT MATCH',
                   style: TextStyle(
@@ -1583,7 +1596,7 @@ class _GameScreenState extends State<GameScreen> {
       final missPct = 100 - hitPct;
       final pointsSum = pThrows.fold<int>(0, (acc, t) => acc + t.segment * t.multiplier);
       final avg = total == 0 ? 0.0 : (pointsSum / total) * 3;
-      final lastLabel = _lastDartsLabel(i);
+      final lastLabel = _previousTurnLabel(i);
       final lastSum = _sumOfLastThreeBeforeCurrentTurn(i);
       rows.add(PlayerOverviewRow(
         name: p.name,
@@ -1599,7 +1612,7 @@ class _GameScreenState extends State<GameScreen> {
     Navigator.of(context).push(MaterialPageRoute(
       builder: (_) => DossedartPlayerOverviewScreen(
         title: 'CAST · X01 ${widget.startingScore}',
-        roundNumber: _currentRound(),
+        roundNumber: _roundNumber + 1,
         rows: rows,
       ),
     ));

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -22,6 +22,12 @@ import '../services/game_logger.dart';
 import 'post_game_screen.dart';
 import '../widgets/mid_game_player_sheet.dart';
 import '../services/battery_sampler.dart';
+import '../widgets/dossedart/dossedart_crt_frame.dart';
+import '../widgets/dossedart/x01/dossedart_x01_active_card.dart';
+import '../widgets/dossedart/x01/dossedart_x01_action_bar.dart';
+import '../widgets/dossedart/x01/dossedart_x01_dartboard.dart';
+import '../widgets/dossedart/x01/dossedart_x01_topbar.dart';
+import 'dossedart/x01/dossedart_player_overview_screen.dart';
 
 enum _ThrowOutcome { continueTurn, finish, turnEndNoBust, bust }
 
@@ -1422,9 +1428,180 @@ class _GameScreenState extends State<GameScreen> {
   }
 
   Widget _buildDossedartCockpit(BuildContext context) {
-    // Placeholder — Task 12 wires the real cockpit. For now defer to
-    // classic so the app still works during the refactor.
-    return _buildClassicScaffold(context);
+    final player = players[currentPlayerIndex];
+    final lastLabel = _lastDartsLabel(currentPlayerIndex);
+    final tip = _checkoutFor(player.score);
+
+    // Last-turn sum (sum of the three throws ending the previous turn).
+    final lastSum = _sumOfLastThreeBeforeCurrentTurn(currentPlayerIndex);
+
+    final title = 'X01 · ${widget.startingScore} · ${_outRuleLabel()}';
+
+    return Scaffold(
+      backgroundColor: const Color(0xFF0A0014),
+      body: DossedartCrtFrame(
+        child: SafeArea(
+          child: Stack(
+            children: [
+              Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  DossedartX01TopBar(
+                    title: title,
+                    legIndex: 1,
+                    legCount: 1,
+                    roundNumber: _currentRound(),
+                    onExit: _confirmExit,
+                  ),
+                  DossedartX01ActiveCard(
+                    playerName: player.name,
+                    avatarPath: player.avatarPath,
+                    accentColor: const Color(0xFFFF00AA),
+                    remaining: player.score,
+                    currentDartIndex: dartsInTurn,
+                    lastTurnLabel: lastLabel.isEmpty ? null : lastLabel,
+                    lastTurnSum: lastSum,
+                    checkoutTip: tip.isEmpty ? null : tip,
+                  ),
+                ],
+              ),
+              // Dartboard — fixed position, never shifts with active card height
+              Positioned(
+                left: 14, right: 14, bottom: 74,
+                child: AspectRatio(
+                  aspectRatio: 1,
+                  child: Container(
+                    decoration: BoxDecoration(
+                      border: Border.all(color: const Color(0xFFFF00AA), width: 3),
+                      boxShadow: [
+                        BoxShadow(color: const Color(0xFFFF00AA).withValues(alpha: 0.4), blurRadius: 14),
+                      ],
+                    ),
+                    child: DossedartX01Dartboard(
+                      onTap: (zone) {
+                        final (seg, mult) = zone.toSegmentMultiplier();
+                        if (seg == 0) {
+                          _onMiss();
+                        } else {
+                          _onDartHit(seg, mult);
+                        }
+                      },
+                    ),
+                  ),
+                ),
+              ),
+              Positioned(
+                left: 0, right: 0, bottom: 0,
+                child: DossedartX01ActionBar(
+                  onUndo: _undo,
+                  onMiss: _onMiss,
+                  onMenu: () => _showDossedartMenu(context),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _outRuleLabel() {
+    switch (widget.masterOut) {
+      case 'double': return 'D-OUT';
+      case 'master': return 'MASTER';
+      default: return 'FREE';
+    }
+  }
+
+  int _currentRound() {
+    // Round number = (total darts thrown by the index-0 player) ~/ 3 + 1.
+    final p0Darts = throwHistory.where((t) => t.playerIndex == 0).length;
+    return (p0Darts ~/ 3) + 1;
+  }
+
+  int _sumOfLastThreeBeforeCurrentTurn(int playerIndex) {
+    final all = throwHistory.where((t) => t.playerIndex == playerIndex).toList();
+    // Exclude darts in the current in-progress turn (those count toward dartsInTurn).
+    final completedCount = all.length - dartsInTurn;
+    if (completedCount < 3) return 0;
+    final lastThree = all.sublist(completedCount - 3, completedCount);
+    return lastThree.fold(0, (acc, t) => acc + t.segment * t.multiplier);
+  }
+
+  void _showDossedartMenu(BuildContext outerContext) {
+    showModalBottomSheet(
+      context: outerContext,
+      backgroundColor: const Color(0xFF1A0030),
+      builder: (sheetCtx) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.scoreboard, color: Color(0xFF00E5FF)),
+                title: const Text(
+                  'PLAYER OVERVIEW',
+                  style: TextStyle(
+                    fontFamily: 'PressStart2P', fontSize: 11, color: Colors.white, letterSpacing: 1.5,
+                  ),
+                ),
+                onTap: () {
+                  Navigator.pop(sheetCtx);
+                  _openPlayerOverview();
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.exit_to_app, color: Color(0xFFFF3050)),
+                title: const Text(
+                  'EXIT MATCH',
+                  style: TextStyle(
+                    fontFamily: 'PressStart2P', fontSize: 11, color: Colors.white, letterSpacing: 1.5,
+                  ),
+                ),
+                onTap: () {
+                  Navigator.pop(sheetCtx);
+                  _confirmExit();
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  void _openPlayerOverview() {
+    final rows = <PlayerOverviewRow>[];
+    for (int i = 0; i < players.length; i++) {
+      final p = players[i];
+      final pThrows = throwHistory.where((t) => t.playerIndex == i).toList();
+      final hits = pThrows.where((t) => t.segment != 0).length;
+      final total = pThrows.length;
+      final hitPct = total == 0 ? 0 : (hits * 100 / total).round();
+      final missPct = 100 - hitPct;
+      final pointsSum = pThrows.fold<int>(0, (acc, t) => acc + t.segment * t.multiplier);
+      final avg = total == 0 ? 0.0 : (pointsSum / total) * 3;
+      final lastLabel = _lastDartsLabel(i);
+      final lastSum = _sumOfLastThreeBeforeCurrentTurn(i);
+      rows.add(PlayerOverviewRow(
+        name: p.name,
+        avatarPath: p.avatarPath,
+        remaining: p.score,
+        lastTurnLabel: lastLabel.isEmpty ? '— · — · —' : lastLabel,
+        lastTurnSum: lastSum,
+        avg: avg,
+        hitPct: hitPct,
+        missPct: missPct,
+      ));
+    }
+    Navigator.of(context).push(MaterialPageRoute(
+      builder: (_) => DossedartPlayerOverviewScreen(
+        title: 'CAST · X01 ${widget.startingScore}',
+        roundNumber: _currentRound(),
+        rows: rows,
+      ),
+    ));
   }
 
   Widget _buildClassicScaffold(BuildContext context) {

--- a/lib/widgets/dossedart/dossedart_crt_frame.dart
+++ b/lib/widgets/dossedart/dossedart_crt_frame.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import '../../theme/dossedart_tokens.dart';
+import 'arcade_frame.dart';
+
+/// Wraps a screen body with the DOSSEDART CRT treatment:
+/// - ArcadeFrame (scanlines, vignette, scan-beam)
+/// - Inset shadows simulating CRT-glass corner-darkening
+/// - 16px border radius on the inner frame
+///
+/// The "physical bezel" shown in design mockups (grey plastic surround
+/// with power LED) is decorative-only in the mockup; in Flutter we
+/// convey the CRT feel via inset shadows alone.
+class DossedartCrtFrame extends StatelessWidget {
+  const DossedartCrtFrame({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: DossedartTokens.bg,
+      child: Stack(
+        children: [
+          Positioned.fill(child: ArcadeFrame(child: child)),
+          // Inset shadow overlay (CRT glass-bulge darkening)
+          const Positioned.fill(
+            child: IgnorePointer(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  boxShadow: [
+                    BoxShadow(
+                      color: Color(0xB3000000), // 70% black
+                      blurRadius: 60,
+                      spreadRadius: -30,
+                      offset: Offset.zero,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/dossedart/dossedart_player_avatar.dart
+++ b/lib/widgets/dossedart/dossedart_player_avatar.dart
@@ -11,14 +11,12 @@ import 'package:flutter/material.dart';
 class DossedartPlayerAvatar extends StatelessWidget {
   const DossedartPlayerAvatar({
     super.key,
-    required this.name,
     required this.size,
     required this.borderColor,
     this.avatarPath,
     this.borderWidth = 3,
   });
 
-  final String name;
   final double size;
   final Color borderColor;
   final String? avatarPath;

--- a/lib/widgets/dossedart/dossedart_player_avatar.dart
+++ b/lib/widgets/dossedart/dossedart_player_avatar.dart
@@ -1,0 +1,58 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+
+/// Square avatar with a 2-3px player-color border. Shows the photo
+/// when available, falls back to an Icons.person silhouette.
+///
+/// Used by the DOSSEDART cockpit active card and Player Overview rows.
+/// Square shape and the per-player border colour are the DOSSEDART
+/// look — different from the round CircleAvatar that `PlayerAvatar` uses.
+class DossedartPlayerAvatar extends StatelessWidget {
+  const DossedartPlayerAvatar({
+    super.key,
+    required this.name,
+    required this.size,
+    required this.borderColor,
+    this.avatarPath,
+    this.borderWidth = 3,
+  });
+
+  final String name;
+  final double size;
+  final Color borderColor;
+  final String? avatarPath;
+  final double borderWidth;
+
+  bool _hasPhoto() {
+    if (avatarPath == null || avatarPath!.isEmpty || kIsWeb) return false;
+    return File(avatarPath!).existsSync();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: const Color(0xFF2A0050),
+        border: Border.all(color: borderColor, width: borderWidth),
+        boxShadow: [
+          BoxShadow(
+            color: borderColor.withValues(alpha: 0.5),
+            blurRadius: 8,
+          ),
+        ],
+      ),
+      child: _hasPhoto()
+          ? Image.file(File(avatarPath!), fit: BoxFit.cover)
+          : Center(
+              child: Icon(
+                Icons.person,
+                size: size * 0.6,
+                color: Colors.white,
+              ),
+            ),
+    );
+  }
+}

--- a/lib/widgets/dossedart/x01/dart_zone.dart
+++ b/lib/widgets/dossedart/x01/dart_zone.dart
@@ -1,0 +1,57 @@
+/// A region on the DOSSEDART dartboard that a tap can resolve to.
+///
+/// Use [toSegmentMultiplier] to feed the result into the existing
+/// `_GameScreenState._onDartHit(int segment, int multiplier)` API.
+sealed class DartZone {
+  const DartZone();
+
+  const factory DartZone.single(int n) = _Single;
+  const factory DartZone.double_(int n) = _Double;
+  const factory DartZone.triple(int n) = _Triple;
+  const factory DartZone.bull() = _Bull;
+  const factory DartZone.dBull() = _DBull;
+  const factory DartZone.miss() = _Miss;
+
+  /// (segment, multiplier) pair for the production scoring engine.
+  /// MISS maps to (0, 1) so points = 0 * 1 = 0.
+  (int, int) toSegmentMultiplier();
+}
+
+class _Single extends DartZone {
+  const _Single(this.n);
+  final int n;
+  @override
+  (int, int) toSegmentMultiplier() => (n, 1);
+}
+
+class _Double extends DartZone {
+  const _Double(this.n);
+  final int n;
+  @override
+  (int, int) toSegmentMultiplier() => (n, 2);
+}
+
+class _Triple extends DartZone {
+  const _Triple(this.n);
+  final int n;
+  @override
+  (int, int) toSegmentMultiplier() => (n, 3);
+}
+
+class _Bull extends DartZone {
+  const _Bull();
+  @override
+  (int, int) toSegmentMultiplier() => (25, 1);
+}
+
+class _DBull extends DartZone {
+  const _DBull();
+  @override
+  (int, int) toSegmentMultiplier() => (25, 2);
+}
+
+class _Miss extends DartZone {
+  const _Miss();
+  @override
+  (int, int) toSegmentMultiplier() => (0, 1);
+}

--- a/lib/widgets/dossedart/x01/dart_zone.dart
+++ b/lib/widgets/dossedart/x01/dart_zone.dart
@@ -22,6 +22,10 @@ class _Single extends DartZone {
   final int n;
   @override
   (int, int) toSegmentMultiplier() => (n, 1);
+  @override
+  bool operator ==(Object other) => other is _Single && other.n == n;
+  @override
+  int get hashCode => Object.hash(_Single, n);
 }
 
 class _Double extends DartZone {
@@ -29,6 +33,10 @@ class _Double extends DartZone {
   final int n;
   @override
   (int, int) toSegmentMultiplier() => (n, 2);
+  @override
+  bool operator ==(Object other) => other is _Double && other.n == n;
+  @override
+  int get hashCode => Object.hash(_Double, n);
 }
 
 class _Triple extends DartZone {
@@ -36,22 +44,38 @@ class _Triple extends DartZone {
   final int n;
   @override
   (int, int) toSegmentMultiplier() => (n, 3);
+  @override
+  bool operator ==(Object other) => other is _Triple && other.n == n;
+  @override
+  int get hashCode => Object.hash(_Triple, n);
 }
 
 class _Bull extends DartZone {
   const _Bull();
   @override
   (int, int) toSegmentMultiplier() => (25, 1);
+  @override
+  bool operator ==(Object other) => other is _Bull;
+  @override
+  int get hashCode => runtimeType.hashCode;
 }
 
 class _DBull extends DartZone {
   const _DBull();
   @override
   (int, int) toSegmentMultiplier() => (25, 2);
+  @override
+  bool operator ==(Object other) => other is _DBull;
+  @override
+  int get hashCode => runtimeType.hashCode;
 }
 
 class _Miss extends DartZone {
   const _Miss();
   @override
   (int, int) toSegmentMultiplier() => (0, 1);
+  @override
+  bool operator ==(Object other) => other is _Miss;
+  @override
+  int get hashCode => runtimeType.hashCode;
 }

--- a/lib/widgets/dossedart/x01/dossedart_x01_action_bar.dart
+++ b/lib/widgets/dossedart/x01/dossedart_x01_action_bar.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import '../../../theme/dossedart_tokens.dart';
+
+/// DOSSEDART X01 cockpit action bar: ↶ UNDO · ✗ MISS · ⋯ MENU.
+///
+/// UNDO — magenta border, flex 1.
+/// MISS — filled orange (primary), flex 2.
+/// MENU — cyan border, flex 1.
+class DossedartX01ActionBar extends StatelessWidget {
+  const DossedartX01ActionBar({
+    super.key,
+    required this.onUndo,
+    required this.onMiss,
+    required this.onMenu,
+  });
+
+  final VoidCallback onUndo;
+  final VoidCallback onMiss;
+  final VoidCallback onMenu;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+      decoration: const BoxDecoration(
+        color: Colors.black,
+        border: Border(
+          top: BorderSide(color: DossedartTokens.yellow, width: 2),
+        ),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            flex: 1,
+            child: _Btn(
+              label: '↶ UNDO',
+              borderColor: DossedartTokens.magenta,
+              fg: Colors.white,
+              onTap: onUndo,
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            flex: 2,
+            child: _Btn(
+              label: '✗ MISS',
+              borderColor: Colors.white,
+              bg: DossedartTokens.orange,
+              fg: Colors.black,
+              onTap: onMiss,
+              glow: true,
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            flex: 1,
+            child: _Btn(
+              label: '⋯ MENU',
+              borderColor: DossedartTokens.cyan,
+              fg: DossedartTokens.cyan,
+              onTap: onMenu,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Btn extends StatelessWidget {
+  const _Btn({
+    required this.label,
+    required this.borderColor,
+    required this.fg,
+    required this.onTap,
+    this.bg,
+    this.glow = false,
+  });
+
+  final String label;
+  final Color borderColor;
+  final Color fg;
+  final VoidCallback onTap;
+  final Color? bg;
+  final bool glow;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        decoration: BoxDecoration(
+          color: bg,
+          border: Border.all(color: borderColor, width: 2),
+          boxShadow: glow
+              ? [
+                  BoxShadow(
+                    color: DossedartTokens.orange.withValues(alpha: 0.55),
+                    blurRadius: 16,
+                  )
+                ]
+              : null,
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          label,
+          style: TextStyle(
+            fontFamily: 'PressStart2P',
+            fontSize: 11,
+            color: fg,
+            letterSpacing: 1.5,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/dossedart/x01/dossedart_x01_active_card.dart
+++ b/lib/widgets/dossedart/x01/dossedart_x01_active_card.dart
@@ -202,6 +202,7 @@ class DossedartX01ActiveCard extends StatelessWidget {
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
               decoration: BoxDecoration(
                 color: DossedartTokens.green.withValues(alpha: 0.06),
+                // Spec calls for a dashed border; Flutter has no native dashed support, rendered solid.
                 border: Border.all(color: DossedartTokens.green, width: 2),
                 boxShadow: [
                   BoxShadow(

--- a/lib/widgets/dossedart/x01/dossedart_x01_active_card.dart
+++ b/lib/widgets/dossedart/x01/dossedart_x01_active_card.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import '../../../theme/dossedart_tokens.dart';
+import '../dossedart_player_avatar.dart';
+
+/// Active player card shown in the DOSSEDART X01 cockpit.
+class DossedartX01ActiveCard extends StatelessWidget {
+  const DossedartX01ActiveCard({
+    super.key,
+    required this.playerName,
+    required this.avatarPath,
+    required this.accentColor,
+    required this.remaining,
+    required this.currentDartIndex,
+    required this.lastTurnLabel,
+    required this.lastTurnSum,
+    required this.checkoutTip,
+  });
+
+  final String playerName;
+  final String? avatarPath;
+  final Color accentColor;
+  final int remaining;
+  final int currentDartIndex; // 0..3
+  final String? lastTurnLabel; // e.g., 'T20 · S20 · S20' (null = no previous turn)
+  final int? lastTurnSum;
+  final String? checkoutTip;
+
+  double _nameFontSize() {
+    final len = playerName.length;
+    if (len <= 6) return 18;
+    if (len <= 10) return 15;
+    if (len <= 16) return 12;
+    return 10;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final nameSize = _nameFontSize();
+    return Container(
+      margin: const EdgeInsets.fromLTRB(14, 12, 14, 10),
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+      decoration: BoxDecoration(
+        border: Border.all(color: accentColor, width: 3),
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            accentColor.withValues(alpha: 0.10),
+            accentColor.withValues(alpha: 0.02),
+          ],
+        ),
+        boxShadow: [
+          BoxShadow(color: accentColor.withValues(alpha: 0.25), blurRadius: 14),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Row 1: avatar + name + dart-dots
+          Row(
+            children: [
+              DossedartPlayerAvatar(
+                avatarPath: avatarPath,
+                size: 56,
+                borderColor: accentColor,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      playerName,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontFamily: 'PressStart2P',
+                        fontSize: nameSize,
+                        color: Colors.white,
+                        letterSpacing: nameSize >= 15 ? 2 : 1.5,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Row(
+                      children: [
+                        for (int i = 0; i < 3; i++) ...[
+                          Container(
+                            width: 9,
+                            height: 9,
+                            decoration: BoxDecoration(
+                              color: i < currentDartIndex
+                                  ? accentColor
+                                  : Colors.transparent,
+                              border: Border.all(color: accentColor, width: 2),
+                            ),
+                          ),
+                          const SizedBox(width: 6),
+                        ],
+                        Text(
+                          'DART $currentDartIndex/3',
+                          style: const TextStyle(
+                            fontFamily: 'VT323',
+                            fontSize: 13,
+                            color: Colors.white54,
+                            letterSpacing: 1,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          // Row 2: REMAINING label + big number
+          const SizedBox(height: 12),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              const Text(
+                'REMAINING',
+                style: TextStyle(
+                  fontFamily: 'PressStart2P',
+                  fontSize: 9,
+                  color: Colors.white70,
+                  letterSpacing: 1.5,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                '$remaining',
+                style: TextStyle(
+                  fontFamily: 'PressStart2P',
+                  fontSize: 60,
+                  color: accentColor,
+                  letterSpacing: 2,
+                  height: 1,
+                  shadows: [
+                    Shadow(
+                        color: accentColor.withValues(alpha: 0.7),
+                        blurRadius: 16),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          // Row 3: last turn (above thin separator)
+          if (lastTurnLabel != null) ...[
+            const SizedBox(height: 10),
+            Container(
+              padding: const EdgeInsets.only(top: 8),
+              decoration: BoxDecoration(
+                border: Border(
+                  top: BorderSide(
+                    color: accentColor.withValues(alpha: 0.4),
+                    width: 1,
+                  ),
+                ),
+              ),
+              child: Row(
+                children: [
+                  const Text(
+                    'LAST',
+                    style: TextStyle(
+                      fontFamily: 'PressStart2P',
+                      fontSize: 9,
+                      color: Colors.white70,
+                      letterSpacing: 1.5,
+                    ),
+                  ),
+                  Expanded(
+                    child: Text(
+                      lastTurnLabel!,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        fontFamily: 'VT323',
+                        fontSize: 20,
+                        color: DossedartTokens.yellow,
+                        letterSpacing: 1.5,
+                      ),
+                    ),
+                  ),
+                  if (lastTurnSum != null)
+                    Text(
+                      '= $lastTurnSum',
+                      style: const TextStyle(
+                        fontFamily: 'PressStart2P',
+                        fontSize: 13,
+                        color: DossedartTokens.yellow,
+                        letterSpacing: 1,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+          // Row 4: checkout tip
+          if (checkoutTip != null) ...[
+            const SizedBox(height: 10),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              decoration: BoxDecoration(
+                color: DossedartTokens.green.withValues(alpha: 0.06),
+                border: Border.all(color: DossedartTokens.green, width: 2),
+                boxShadow: [
+                  BoxShadow(
+                    color: DossedartTokens.green.withValues(alpha: 0.4),
+                    blurRadius: 14,
+                  ),
+                ],
+              ),
+              child: Text(
+                '▶ $checkoutTip',
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontFamily: 'PressStart2P',
+                  fontSize: 10,
+                  color: DossedartTokens.green,
+                  letterSpacing: 1,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/dossedart/x01/dossedart_x01_dartboard.dart
+++ b/lib/widgets/dossedart/x01/dossedart_x01_dartboard.dart
@@ -1,0 +1,159 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+import '../../../theme/dossedart_tokens.dart';
+import 'dart_zone.dart';
+
+/// Standard dart segment order starting at 20 (top), going clockwise.
+const List<int> kSegmentOrder = [
+  20, 1, 18, 4, 13, 6, 10, 15, 2, 17, 3, 19, 7, 16, 8, 11, 14, 9, 12, 5,
+];
+
+// Radius thresholds as fractions of board radius.
+// Visual = hit-test (no surprise misses).
+const double kDBullR = 0.05;
+const double kBullR = 0.12;
+const double kInnerSingleR = 0.47;
+const double kTripleR = 0.58;
+const double kOuterSingleR = 0.82;
+const double kDoubleR = 0.95;
+
+/// Resolve a tap at polar (r, angleDeg) — r as a fraction of board
+/// radius, angleDeg measured clockwise from 12 o'clock — to a DartZone.
+DartZone zoneForPolar(double r, double angleDeg) {
+  if (r <= kDBullR) return const DartZone.dBull();
+  if (r <= kBullR) return const DartZone.bull();
+  if (r > kDoubleR) return const DartZone.miss();
+
+  // Normalise angle to [0, 360).
+  double a = angleDeg % 360;
+  if (a < 0) a += 360;
+  // Each segment is 18°, centred on its number. Segment 0 (the "20"
+  // segment) spans [-9°, 9°). So shift by +9° to make segment 0 start at 0°.
+  final segIdx = ((a + 9) % 360 / 18).floor();
+  final n = kSegmentOrder[segIdx];
+
+  if (r <= kInnerSingleR) return DartZone.single(n);
+  if (r <= kTripleR) return DartZone.triple(n);
+  if (r <= kOuterSingleR) return DartZone.single(n);
+  return DartZone.double_(n);
+}
+
+/// Renders the DOSSEDART arcade dartboard and reports taps as DartZones.
+/// The widget fills its available space; wrap in an AspectRatio(1) to
+/// keep it square.
+class DossedartX01Dartboard extends StatelessWidget {
+  const DossedartX01Dartboard({super.key, required this.onTap});
+
+  final ValueChanged<DartZone> onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (ctx, constraints) {
+        final size = math.min(constraints.maxWidth, constraints.maxHeight);
+        return GestureDetector(
+          onTapUp: (details) {
+            final centre = Offset(size / 2, size / 2);
+            final offset = details.localPosition - centre;
+            final boardRadius = size / 2;
+            final r = offset.distance / boardRadius;
+            final angleRad = math.atan2(offset.dx, -offset.dy); // 12 o'clock = 0, CW positive
+            final angleDeg = angleRad * 180 / math.pi;
+            onTap(zoneForPolar(r, angleDeg));
+          },
+          child: SizedBox(
+            width: size,
+            height: size,
+            child: CustomPaint(painter: _DartboardPainter()),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _DartboardPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final r = size.width / 2;
+    final c = Offset(r, r);
+
+    // Outer frame (magenta border + glow already comes from surrounding
+    // BoxDecoration on the parent; here we just fill background).
+    final bg = Paint()..color = DossedartTokens.surface;
+    canvas.drawCircle(c, r, bg);
+
+    const slice = math.pi * 2 / 20;
+    for (int i = 0; i < 20; i++) {
+      final start = -slice / 2 + i * slice - math.pi / 2;
+      final end = start + slice;
+      final segCol = (i % 2 == 0)
+          ? DossedartTokens.magenta.withValues(alpha: 0.35)
+          : DossedartTokens.cyan.withValues(alpha: 0.35);
+
+      _wedge(canvas, c, r * kBullR, r * kInnerSingleR, start, end, segCol);
+      _wedge(canvas, c, r * kInnerSingleR, r * kTripleR, start, end, DossedartTokens.green);
+      _wedge(canvas, c, r * kTripleR, r * kOuterSingleR, start, end, segCol);
+      _wedge(canvas, c, r * kOuterSingleR, r * kDoubleR, start, end, DossedartTokens.yellow);
+      _wedge(canvas, c, r * kDoubleR, r, start, end, DossedartTokens.bg);
+
+      // Segment number label, placed in the outer band.
+      final midAng = (start + end) / 2;
+      final lx = c.dx + math.cos(midAng) * r * 0.975;
+      final ly = c.dy + math.sin(midAng) * r * 0.975;
+      final n = kSegmentOrder[i];
+      final tp = TextPainter(
+        text: TextSpan(
+          text: '$n',
+          style: const TextStyle(
+            fontFamily: 'PressStart2P',
+            fontSize: 11,
+            color: Colors.white,
+          ),
+        ),
+        textDirection: TextDirection.ltr,
+      )..layout();
+      tp.paint(canvas, Offset(lx - tp.width / 2, ly - tp.height / 2));
+    }
+
+    // Bull / D-Bull
+    canvas.drawCircle(c, r * kBullR, Paint()..color = DossedartTokens.orange);
+    canvas.drawCircle(c, r * kDBullR, Paint()..color = DossedartTokens.red);
+
+    // White stroke around bulls
+    final stroke = Paint()
+      ..color = Colors.white
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2;
+    canvas.drawCircle(c, r * kBullR, stroke);
+    canvas.drawCircle(c, r * kDBullR, stroke);
+
+    // Magenta border ring
+    final border = Paint()
+      ..color = DossedartTokens.magenta
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 3;
+    canvas.drawCircle(c, r - 1.5, border);
+  }
+
+  void _wedge(Canvas canvas, Offset c, double rInner, double rOuter,
+      double startAng, double endAng, Color fill) {
+    final path = Path()
+      ..moveTo(c.dx + math.cos(startAng) * rInner, c.dy + math.sin(startAng) * rInner)
+      ..lineTo(c.dx + math.cos(startAng) * rOuter, c.dy + math.sin(startAng) * rOuter)
+      ..arcTo(
+        Rect.fromCircle(center: c, radius: rOuter),
+        startAng, endAng - startAng, false,
+      )
+      ..lineTo(c.dx + math.cos(endAng) * rInner, c.dy + math.sin(endAng) * rInner)
+      ..arcTo(
+        Rect.fromCircle(center: c, radius: rInner),
+        endAng, -(endAng - startAng), false,
+      )
+      ..close();
+    canvas.drawPath(path, Paint()..color = fill);
+  }
+
+  @override
+  bool shouldRepaint(_DartboardPainter oldDelegate) => false;
+}

--- a/lib/widgets/dossedart/x01/dossedart_x01_topbar.dart
+++ b/lib/widgets/dossedart/x01/dossedart_x01_topbar.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import '../../../theme/dossedart_tokens.dart';
+
+/// DOSSEDART X01 cockpit top bar: ◀ EXIT · title · L n/m · RND r.
+class DossedartX01TopBar extends StatelessWidget {
+  const DossedartX01TopBar({
+    super.key,
+    required this.title,
+    required this.legIndex,
+    required this.legCount,
+    required this.roundNumber,
+    required this.onExit,
+  });
+
+  final String title;
+  final int legIndex;
+  final int legCount;
+  final int roundNumber;
+  final VoidCallback onExit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: const BoxDecoration(
+        color: Colors.black,
+        border: Border(
+          bottom: BorderSide(color: DossedartTokens.magenta, width: 2),
+        ),
+      ),
+      child: Row(
+        children: [
+          GestureDetector(
+            onTap: onExit,
+            child: const Text(
+              '◀ EXIT',
+              style: TextStyle(
+                fontFamily: 'VT323',
+                fontSize: 18,
+                color: DossedartTokens.cyan,
+                letterSpacing: 2,
+                height: 1,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Center(
+              child: Text(
+                title,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  fontFamily: 'PressStart2P',
+                  fontSize: 11,
+                  color: DossedartTokens.yellow,
+                  letterSpacing: 2,
+                  height: 1.3,
+                ),
+              ),
+            ),
+          ),
+          Text(
+            'L $legIndex/$legCount · RND $roundNumber',
+            style: const TextStyle(
+              fontFamily: 'VT323',
+              fontSize: 14,
+              color: Colors.white54,
+              letterSpacing: 2,
+              height: 1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/widgets/dossedart/dossedart_crt_frame_test.dart
+++ b/test/widgets/dossedart/dossedart_crt_frame_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_scoring/widgets/dossedart/arcade_frame.dart';
+import 'package:dart_scoring/widgets/dossedart/dossedart_crt_frame.dart';
+
+void main() {
+  setUp(() {
+    ArcadeFrame.disableBeamForTest = true;
+  });
+  tearDown(() {
+    ArcadeFrame.disableBeamForTest = false;
+  });
+
+  testWidgets('renders child without throwing', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: DossedartCrtFrame(
+        child: Text('inner'),
+      ),
+    ));
+    expect(find.text('inner'), findsOneWidget);
+    expect(find.byType(ArcadeFrame), findsOneWidget);
+  });
+}

--- a/test/widgets/dossedart/dossedart_player_avatar_test.dart
+++ b/test/widgets/dossedart/dossedart_player_avatar_test.dart
@@ -8,7 +8,6 @@ void main() {
     await tester.pumpWidget(const MaterialApp(
       home: Scaffold(
         body: DossedartPlayerAvatar(
-          name: 'TEST',
           avatarPath: null,
           size: 56,
           borderColor: Color(0xFFFF00AA),
@@ -23,7 +22,6 @@ void main() {
     await tester.pumpWidget(const MaterialApp(
       home: Scaffold(
         body: DossedartPlayerAvatar(
-          name: 'TEST',
           avatarPath: '/nonexistent/path/to/file.jpg',
           size: 56,
           borderColor: Color(0xFFFF00AA),

--- a/test/widgets/dossedart/dossedart_player_avatar_test.dart
+++ b/test/widgets/dossedart/dossedart_player_avatar_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_scoring/widgets/dossedart/dossedart_player_avatar.dart';
+
+void main() {
+  testWidgets('shows Icons.person silhouette when avatarPath is null',
+      (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: DossedartPlayerAvatar(
+          name: 'TEST',
+          avatarPath: null,
+          size: 56,
+          borderColor: Color(0xFFFF00AA),
+        ),
+      ),
+    ));
+    expect(find.byIcon(Icons.person), findsOneWidget);
+  });
+
+  testWidgets('shows Icons.person silhouette when avatarPath does not exist',
+      (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: DossedartPlayerAvatar(
+          name: 'TEST',
+          avatarPath: '/nonexistent/path/to/file.jpg',
+          size: 56,
+          borderColor: Color(0xFFFF00AA),
+        ),
+      ),
+    ));
+    expect(find.byIcon(Icons.person), findsOneWidget);
+  });
+}

--- a/test/widgets/dossedart/x01/dart_zone_test.dart
+++ b/test/widgets/dossedart/x01/dart_zone_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_scoring/widgets/dossedart/x01/dart_zone.dart';
+
+void main() {
+  group('DartZone.toSegmentMultiplier', () {
+    test('single 20 → (20, 1)', () {
+      expect(const DartZone.single(20).toSegmentMultiplier(), (20, 1));
+    });
+    test('double 16 → (16, 2)', () {
+      expect(const DartZone.double_(16).toSegmentMultiplier(), (16, 2));
+    });
+    test('triple 19 → (19, 3)', () {
+      expect(const DartZone.triple(19).toSegmentMultiplier(), (19, 3));
+    });
+    test('bull → (25, 1)', () {
+      expect(const DartZone.bull().toSegmentMultiplier(), (25, 1));
+    });
+    test('dBull → (25, 2)', () {
+      expect(const DartZone.dBull().toSegmentMultiplier(), (25, 2));
+    });
+    test('miss → (0, 1)', () {
+      expect(const DartZone.miss().toSegmentMultiplier(), (0, 1));
+    });
+  });
+}

--- a/test/widgets/dossedart/x01/dossedart_x01_action_bar_test.dart
+++ b/test/widgets/dossedart/x01/dossedart_x01_action_bar_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_scoring/widgets/dossedart/x01/dossedart_x01_action_bar.dart';
+
+void main() {
+  testWidgets('renders all three labels', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: DossedartX01ActionBar(
+          onUndo: () {},
+          onMiss: () {},
+          onMenu: () {},
+        ),
+      ),
+    ));
+    expect(find.text('↶ UNDO'), findsOneWidget);
+    expect(find.text('✗ MISS'), findsOneWidget);
+    expect(find.text('⋯ MENU'), findsOneWidget);
+  });
+
+  testWidgets('callbacks fire on tap', (tester) async {
+    var u = false, m = false, x = false;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: DossedartX01ActionBar(
+          onUndo: () => u = true,
+          onMiss: () => m = true,
+          onMenu: () => x = true,
+        ),
+      ),
+    ));
+    await tester.tap(find.text('↶ UNDO'));
+    await tester.tap(find.text('✗ MISS'));
+    await tester.tap(find.text('⋯ MENU'));
+    expect(u, isTrue);
+    expect(m, isTrue);
+    expect(x, isTrue);
+  });
+}

--- a/test/widgets/dossedart/x01/dossedart_x01_active_card_test.dart
+++ b/test/widgets/dossedart/x01/dossedart_x01_active_card_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_scoring/widgets/dossedart/x01/dossedart_x01_active_card.dart';
+
+void main() {
+  Widget harness({
+    String name = 'MIA',
+    int remaining = 170,
+    int currentDartIndex = 2,
+    String? lastTurn = 'T20 · S20 · S20',
+    int? lastTurnSum = 80,
+    String? checkoutTip,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: DossedartX01ActiveCard(
+          playerName: name,
+          avatarPath: null,
+          accentColor: const Color(0xFFFF00AA),
+          remaining: remaining,
+          currentDartIndex: currentDartIndex,
+          lastTurnLabel: lastTurn,
+          lastTurnSum: lastTurnSum,
+          checkoutTip: checkoutTip,
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders name, remaining, last turn', (tester) async {
+    await tester.pumpWidget(harness());
+    expect(find.text('MIA'), findsOneWidget);
+    expect(find.text('170'), findsOneWidget);
+    expect(find.text('T20 · S20 · S20'), findsOneWidget);
+    expect(find.text('= 80'), findsOneWidget);
+  });
+
+  testWidgets('hides checkout-tip when null', (tester) async {
+    await tester.pumpWidget(harness());
+    expect(find.textContaining('▶'), findsNothing);
+  });
+
+  testWidgets('shows checkout-tip when provided', (tester) async {
+    await tester.pumpWidget(harness(checkoutTip: 'T20 › S16 › D-BULL'));
+    expect(find.text('▶ T20 › S16 › D-BULL'), findsOneWidget);
+  });
+
+  testWidgets('long name does not overflow (no exception)',
+      (tester) async {
+    await tester.pumpWidget(harness(name: 'CHRISTOPHER ALEXANDER VON LONGNAME'));
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/widgets/dossedart/x01/dossedart_x01_active_card_test.dart
+++ b/test/widgets/dossedart/x01/dossedart_x01_active_card_test.dart
@@ -50,4 +50,24 @@ void main() {
     await tester.pumpWidget(harness(name: 'CHRISTOPHER ALEXANDER VON LONGNAME'));
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('short name (≤6 chars) renders at 18px font', (tester) async {
+    await tester.pumpWidget(harness(name: 'MIA'));
+    final text = tester.widget<Text>(find.text('MIA'));
+    expect(text.style!.fontSize, 18);
+  });
+
+  testWidgets('medium name (7-10 chars) renders at 15px font',
+      (tester) async {
+    await tester.pumpWidget(harness(name: 'BJORN T.'));
+    final text = tester.widget<Text>(find.text('BJORN T.'));
+    expect(text.style!.fontSize, 15);
+  });
+
+  testWidgets('long name (11-16 chars) renders at 12px font',
+      (tester) async {
+    await tester.pumpWidget(harness(name: 'BJORN TORJUS'));
+    final text = tester.widget<Text>(find.text('BJORN TORJUS'));
+    expect(text.style!.fontSize, 12);
+  });
 }

--- a/test/widgets/dossedart/x01/dossedart_x01_dartboard_test.dart
+++ b/test/widgets/dossedart/x01/dossedart_x01_dartboard_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_scoring/widgets/dossedart/x01/dart_zone.dart';
+import 'package:dart_scoring/widgets/dossedart/x01/dossedart_x01_dartboard.dart';
+
+void main() {
+  group('hit-test', () {
+    // Board has radius 100 in unit space; centre at (0,0).
+    // Angles: 0° = top (12 o'clock), clockwise positive.
+
+    test('centre tap → dBull', () {
+      expect(zoneForPolar(0, 0), const DartZone.dBull());
+    });
+
+    test('inside bull ring (r=0.10) → bull', () {
+      expect(zoneForPolar(0.10, 0), const DartZone.bull());
+    });
+
+    test('inner single at top (r=0.30, angle 0) → single 20', () {
+      expect(zoneForPolar(0.30, 0), const DartZone.single(20));
+    });
+
+    test('triple ring at top (r=0.52, angle 0) → triple 20', () {
+      expect(zoneForPolar(0.52, 0), const DartZone.triple(20));
+    });
+
+    test('outer single at top (r=0.70, angle 0) → single 20', () {
+      expect(zoneForPolar(0.70, 0), const DartZone.single(20));
+    });
+
+    test('double ring at top (r=0.90, angle 0) → double 20', () {
+      expect(zoneForPolar(0.90, 0), const DartZone.double_(20));
+    });
+
+    test('label band (r=0.98) → miss', () {
+      expect(zoneForPolar(0.98, 0), const DartZone.miss());
+    });
+
+    test('outside the board (r=1.1) → miss', () {
+      expect(zoneForPolar(1.1, 0), const DartZone.miss());
+    });
+
+    test('right side (angle 90°) → segment 6', () {
+      // Per standard ordering, segment 90° clockwise from top is 6.
+      expect(zoneForPolar(0.30, 90), const DartZone.single(6));
+    });
+
+    test('bottom (angle 180°) → segment 3', () {
+      expect(zoneForPolar(0.30, 180), const DartZone.single(3));
+    });
+  });
+
+  testWidgets('GestureDetector fires onTap with computed zone',
+      (tester) async {
+    DartZone? lastZone;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: 320,
+            height: 320,
+            child: DossedartX01Dartboard(
+              onTap: (z) => lastZone = z,
+            ),
+          ),
+        ),
+      ),
+    ));
+    // Tap dead-centre: dBull.
+    await tester.tapAt(tester.getCenter(find.byType(DossedartX01Dartboard)));
+    expect(lastZone, const DartZone.dBull());
+  });
+}

--- a/test/widgets/dossedart/x01/dossedart_x01_topbar_test.dart
+++ b/test/widgets/dossedart/x01/dossedart_x01_topbar_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_scoring/widgets/dossedart/x01/dossedart_x01_topbar.dart';
+
+void main() {
+  testWidgets('renders exit + title + leg/round', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: DossedartX01TopBar(
+          title: 'X01 · 501 · D-OUT',
+          legIndex: 1,
+          legCount: 3,
+          roundNumber: 7,
+          onExit: () {},
+        ),
+      ),
+    ));
+    expect(find.text('◀ EXIT'), findsOneWidget);
+    expect(find.text('X01 · 501 · D-OUT'), findsOneWidget);
+    expect(find.text('L 1/3 · RND 7'), findsOneWidget);
+  });
+
+  testWidgets('onExit callback fires when EXIT tapped', (tester) async {
+    var exited = false;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: DossedartX01TopBar(
+          title: 'X01',
+          legIndex: 1,
+          legCount: 1,
+          roundNumber: 1,
+          onExit: () => exited = true,
+        ),
+      ),
+    ));
+    await tester.tap(find.text('◀ EXIT'));
+    expect(exited, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

DOSSEDART (arcade-styled) X01 in-game cockpit shipping behind the existing \`use_dossedart_design\` preview flag. Default state only — the 7 special game states are explicitly deferred to a follow-up spec.

**New widgets** (under \`lib/widgets/dossedart/\`):
- \`DossedartCrtFrame\` (CRT bezel wrapper)
- \`DossedartPlayerAvatar\` (square photo with silhouette fallback)
- \`DartZone\` (sealed sum-type)
- \`DossedartX01TopBar\`, \`DossedartX01ActiveCard\`, \`DossedartX01Dartboard\`, \`DossedartX01ActionBar\`

**New screen:** \`DossedartPlayerOverviewScreen\` (arcade scoreboard, accessible from cockpit MENU).

**GameScreen** branches via new \`useDossedartDesign\` constructor param; classic logic shared (no engine extraction).

**Dartboard:** visual = hit-test (rings rendered at the same width they're tappable at — no surprise misses).

## Out of scope (separate spec)

- 7 game states (BUST, TURN END, full MENU sheet, SUDDEN DEATH, PLAYER REMOVED, LEG WON, MATCH WON)
- DOSSEDART in-game for Cricket / ATC / Killer / Shanghai / Splitscore
- Multi-leg/best-of logic (TopBar hardcodes leg 1/1)

## Test plan

- [x] 192/192 widget tests pass locally
- [x] \`flutter analyze\` clean
- [ ] CI green (widget + Android emulator integration test)
- [ ] Manual: enable DOSSEDART preview in Settings, start X01 501, verify cockpit + dartboard taps + Player Overview navigation

Spec: \`docs/superpowers/specs/2026-05-20-dossedart-x01-cockpit-design.md\`
Plan: \`docs/superpowers/plans/2026-05-20-dossedart-x01-cockpit-plan.md\`
Locked mockups: \`docs/design/dossedart-handoff/PROPOSAL-cockpit-v5.html\`, \`docs/design/dossedart-handoff/PROPOSAL-player-overview-v4.html\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)